### PR TITLE
Add automatic playing partner booking support

### DIFF
--- a/cmd/tee-sniper/main.go
+++ b/cmd/tee-sniper/main.go
@@ -55,16 +55,31 @@ func main() {
 		log.Printf("Found %d available tee times between %s and %s on %s", len(availableTimes), conf.TimeStart, conf.TimeEnd, dateStr)
 
 		timeToBook := teetimes.PickRandomTime(availableTimes)
+		playingPartners := conf.GetPlayingPartnersList()
 
-		log.Printf("Attempting to book tee time: %s on %s", timeToBook.Time, dateStr)
+		log.Printf("Attempting to book tee time: %s on %s for %d people", timeToBook.Time, dateStr, len(playingPartners)+1)
 
-		ok, err = wc.BookTimeSlot(timeToBook, conf.DryRun)
+		bookingID, err := wc.BookTimeSlot(timeToBook, playingPartners, conf.DryRun)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("Failed to book time slot: %s", err.Error())
+			continue
 		}
 
-		if ok {
-			message := fmt.Sprintf("Successfully booked tee time: %s on %s", timeToBook.Time, dateStr)
+		if bookingID != "" {
+			log.Printf("Successfully booked tee time: %s on %s (booking ID: %s)", timeToBook.Time, dateStr, bookingID)
+
+			// Add playing partners to slots 2, 3, etc. (slot 1 is for the main player)
+			for i, partnerID := range playingPartners {
+				slotNumber := i + 2 // slots start at 2 for partners (1 is main player)
+				err := wc.AddPlayingPartner(bookingID, partnerID, slotNumber, conf.DryRun)
+				if err != nil {
+					log.Printf("Failed to add playing partner %s to slot %d: %s", partnerID, slotNumber, err.Error())
+				} else {
+					log.Printf("Added playing partner %s to slot %d", partnerID, slotNumber)
+				}
+			}
+
+			message := fmt.Sprintf("Successfully booked tee time: %s on %s for %d people", timeToBook.Time, dateStr, len(playingPartners)+1)
 			_, err := twilioClient.SendSms(conf.FromNumber, conf.ToNumber, message, conf.DryRun)
 			if err != nil {
 				log.Printf("Failed to send SMS: %s", err.Error())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"strings"
 
 	flags "github.com/jessevdk/go-flags"
 )
@@ -21,8 +22,9 @@ type Config struct {
 	Pin      string `short:"p" long:"pin" required:"true" description:"The pin associated with the username for booking"`
 	BaseUrl  string `short:"b" long:"baseurl" required:"true" description:"The host for the booking website"`
 
-	FromNumber string `short:"f" long:"fromnumber" required:"true" description:"The number to send the confirmation SMS from"`
-	ToNumber   string `short:"n" long:"tonumber" required:"true" description:"The number to send the confirmation SMS to"`
+	FromNumber      string `short:"f" long:"fromnumber" required:"true" description:"The number to send the confirmation SMS from"`
+	ToNumber        string `short:"n" long:"tonumber" required:"true" description:"The number to send the confirmation SMS to"`
+	PlayingPartners string `short:"s" long:"partners" description:"Comma-separated list of playing partner IDs"`
 }
 
 func GetConfig() (Config, error) {
@@ -38,6 +40,17 @@ func GetConfig() (Config, error) {
 	}
 
 	return c, nil
+}
+
+func (c Config) GetPlayingPartnersList() []string {
+	if c.PlayingPartners == "" {
+		return []string{}
+	}
+	parts := strings.Split(c.PlayingPartners, ",")
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return parts
 }
 
 func isErrHelp(err error) bool {


### PR DESCRIPTION
## Summary
- Add support for automatically booking tee times with playing partners
- New `--partners/-s` command line flag accepts comma-separated partner IDs
- Dynamic slot calculation based on number of partners + main player
- Automatic partner assignment to slots 2, 3, etc. after booking

## Key Changes
- **Config**: Added `PlayingPartners` field with parsing helper method
- **BookingClient**: 
  - Modified `BookTimeSlot()` to accept partner list and return booking ID
  - Added `AddPlayingPartner()` function for partner assignment
  - Added URL parsing to extract booking ID from response
- **Main**: Enhanced booking flow to automatically add all partners after successful booking

## Usage Example
```bash
go run cmd/tee-sniper/main.go -u username -p pin -b https://example.com/ -d 7 -t 15:00 -e 17:00 -n tonumber -f fromnumber -s "partner1,partner2"
```

## Test plan
- [ ] Test booking without partners (existing behavior)  
- [ ] Test booking with 1 partner
- [ ] Test booking with 2 partners
- [ ] Test dry-run mode with partners
- [ ] Test error handling when partner addition fails
- [ ] Verify SMS messages include correct people count

🤖 Generated with [Claude Code](https://claude.ai/code)