### PR TITLE
Upgrade to Go 1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.17'
+        go-version: '1.25'
         
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.17'
+        go-version: '1.25'
         
     - name: Get version from tag
       id: version

--- a/cmd/tee-sniper/main.go
+++ b/cmd/tee-sniper/main.go
@@ -25,8 +25,6 @@ func getRandomRetryDelay(minSeconds, maxSeconds int) time.Duration {
 }
 
 func main() {
-	// Initialize random seed
-	rand.Seed(time.Now().UnixNano())
 	conf, err := config.GetConfig()
 	if err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stebennett/tee-sniper
 
-go 1.17
+go 1.25
 
 require github.com/PuerkitoBio/goquery v1.8.1
 

--- a/go.sum
+++ b/go.sum
@@ -25,11 +25,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/twilio/twilio-go v1.15.1 h1:vdtaMal4+8wxyTETa1zsH6zM2JopOaWj4cye1u09wrA=

--- a/pkg/clients/bookingclient.go
+++ b/pkg/clients/bookingclient.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stebennett/tee-sniper/pkg/models"
@@ -46,7 +45,6 @@ func NewBookingClient(u string) (*BookingClient, error) {
 	}
 
 	// Select a random user agent for this session
-	rand.Seed(time.Now().UnixNano())
 	selectedUserAgent := userAgents[rand.Intn(len(userAgents))]
 
 	return &BookingClient{


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.17 to 1.25 across all configuration files
- Remove deprecated `rand.Seed()` calls (Go 1.20+ auto-seeds from OS entropy)
- Clean up unused imports

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify GitHub Actions CI passes with Go 1.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)