### PR TITLE
Add unit tests for config package

### DIFF
--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -5,7 +5,7 @@
 | Component | File | Tests | Coverage |
 |-----------|------|-------|----------|
 | teetimes | `pkg/teetimes/teetimes.go` | ✅ | 84.6% |
-| config | `pkg/config/config.go` | ❌ | 0% |
+| config | `pkg/config/config.go` | ✅ | 100% |
 | bookingclient | `pkg/clients/bookingclient.go` | ❌ | 0% |
 | twilioclient | `pkg/clients/twilioclient.go` | ❌ | 0% |
 | models | `pkg/models/models.go` | ❌ | 0% |
@@ -90,10 +90,10 @@ mockgen -source=pkg/clients/interfaces.go -destination=pkg/clients/mocks/mock_cl
 | `isErrHelp` | `TestIsErrHelpFalse` | Returns false for other errors |
 
 ### Tasks
-- [ ] Create `pkg/config/config_test.go`
-- [ ] Test `GetPlayingPartnersList()` with various inputs
-- [ ] Test `isErrHelp()` error detection
-- [ ] Test `GetConfig()` with mock os.Args (optional, complex)
+- [x] Create `pkg/config/config_test.go`
+- [x] Test `GetPlayingPartnersList()` with various inputs
+- [x] Test `isErrHelp()` error detection
+- [x] Test `GetConfig()` with mock os.Args (optional, complex)
 
 ---
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,231 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	flags "github.com/jessevdk/go-flags"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPlayingPartnersList(t *testing.T) {
+	tests := []struct {
+		name     string
+		partners string
+		expected []string
+	}{
+		{
+			name:     "empty string returns empty slice",
+			partners: "",
+			expected: []string{},
+		},
+		{
+			name:     "single partner returns slice with one element",
+			partners: "partner1",
+			expected: []string{"partner1"},
+		},
+		{
+			name:     "multiple partners returns multiple elements",
+			partners: "p1,p2,p3",
+			expected: []string{"p1", "p2", "p3"},
+		},
+		{
+			name:     "handles whitespace around values",
+			partners: " p1 , p2 , p3 ",
+			expected: []string{"p1", "p2", "p3"},
+		},
+		{
+			name:     "handles mixed spacing",
+			partners: "p1,  p2,p3  ",
+			expected: []string{"p1", "p2", "p3"},
+		},
+		{
+			name:     "handles tabs and spaces",
+			partners: "	p1	,	p2	",
+			expected: []string{"p1", "p2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{PlayingPartners: tt.partners}
+			result := cfg.GetPlayingPartnersList()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsErrHelpTrue(t *testing.T) {
+	helpErr := &flags.Error{
+		Type:    flags.ErrHelp,
+		Message: "help requested",
+	}
+
+	result := isErrHelp(helpErr)
+	assert.True(t, result, "isErrHelp should return true for help flag error")
+}
+
+func TestIsErrHelpFalse(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "standard error",
+			err:  errors.New("some error"),
+		},
+		{
+			name: "flags error with different type",
+			err: &flags.Error{
+				Type:    flags.ErrRequired,
+				Message: "required flag missing",
+			},
+		},
+		{
+			name: "flags error unknown type",
+			err: &flags.Error{
+				Type:    flags.ErrUnknown,
+				Message: "unknown error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isErrHelp(tt.err)
+			assert.False(t, result, "isErrHelp should return false for non-help errors")
+		})
+	}
+}
+
+func TestGetConfigHelpFlag(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"cmd", "-h"}
+
+	_, err := GetConfig()
+	assert.ErrorIs(t, err, ErrHelp, "GetConfig should return ErrHelp when help flag is passed")
+}
+
+func TestGetConfigMissingRequired(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"cmd"}
+
+	_, err := GetConfig()
+	assert.Error(t, err, "GetConfig should return error when required flags are missing")
+	assert.NotErrorIs(t, err, ErrHelp, "Error should not be ErrHelp")
+}
+
+func TestGetConfigValidArgs(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{
+		"cmd",
+		"-d", "7",
+		"-t", "08:00",
+		"-e", "12:00",
+		"-r", "3",
+		"-u", "testuser",
+		"-p", "1234",
+		"-b", "https://example.com",
+		"-f", "+1234567890",
+		"-n", "+0987654321",
+		"-s", "partner1,partner2",
+	}
+
+	cfg, err := GetConfig()
+	assert.NoError(t, err, "GetConfig should not return error with valid args")
+	assert.Equal(t, 7, cfg.DaysAhead)
+	assert.Equal(t, "08:00", cfg.TimeStart)
+	assert.Equal(t, "12:00", cfg.TimeEnd)
+	assert.Equal(t, 3, cfg.Retries)
+	assert.Equal(t, "testuser", cfg.Username)
+	assert.Equal(t, "1234", cfg.Pin)
+	assert.Equal(t, "https://example.com", cfg.BaseUrl)
+	assert.Equal(t, "+1234567890", cfg.FromNumber)
+	assert.Equal(t, "+0987654321", cfg.ToNumber)
+	assert.Equal(t, "partner1,partner2", cfg.PlayingPartners)
+}
+
+func TestGetConfigDryRunFlag(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{
+		"cmd",
+		"-d", "7",
+		"-t", "08:00",
+		"-e", "12:00",
+		"-r", "3",
+		"-u", "testuser",
+		"-p", "1234",
+		"-b", "https://example.com",
+		"-f", "+1234567890",
+		"-n", "+0987654321",
+		"-x", // dry run flag
+	}
+
+	cfg, err := GetConfig()
+	assert.NoError(t, err, "GetConfig should not return error with valid args")
+	assert.True(t, cfg.DryRun, "DryRun should be true when -x flag is passed")
+}
+
+func TestGetConfigDefaultRetries(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	// Note: go-flags requires the default tag, but also required:"true"
+	// This means retries is required despite having a default
+	// Testing that the value is correctly parsed
+	os.Args = []string{
+		"cmd",
+		"-d", "7",
+		"-t", "08:00",
+		"-e", "12:00",
+		"-r", "5", // using default value
+		"-u", "testuser",
+		"-p", "1234",
+		"-b", "https://example.com",
+		"-f", "+1234567890",
+		"-n", "+0987654321",
+	}
+
+	cfg, err := GetConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, 5, cfg.Retries, "Retries should be 5")
+}
+
+func TestGetConfigOptionalPartners(t *testing.T) {
+	// Save original os.Args and restore after test
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{
+		"cmd",
+		"-d", "7",
+		"-t", "08:00",
+		"-e", "12:00",
+		"-r", "3",
+		"-u", "testuser",
+		"-p", "1234",
+		"-b", "https://example.com",
+		"-f", "+1234567890",
+		"-n", "+0987654321",
+		// No -s flag - partners is optional
+	}
+
+	cfg, err := GetConfig()
+	assert.NoError(t, err, "GetConfig should succeed without optional partners flag")
+	assert.Equal(t, "", cfg.PlayingPartners, "PlayingPartners should be empty string when not provided")
+	assert.Equal(t, []string{}, cfg.GetPlayingPartnersList(), "GetPlayingPartnersList should return empty slice")
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for the `pkg/config` package achieving 100% test coverage
- Implement table-driven tests for `GetPlayingPartnersList()` covering empty strings, single/multiple partners, and whitespace handling
- Add tests for `isErrHelp()` error detection and `GetConfig()` with various argument combinations

## Test plan
- [x] Run `go test -v ./pkg/config/` - all 9 tests pass
- [x] Run `go test -cover ./pkg/config/` - 100% coverage achieved
- [x] Run `go test ./...` - all project tests pass

## Phase 2 of Testing Plan
This PR completes Phase 2 as defined in `TESTING_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)