### PR TITLE
Add Docker support (Phase 1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.env
+.env.example
+*.md
+testdata/
+vendor/
+.github/

--- a/DOCKER_K8S_PLAN.md
+++ b/DOCKER_K8S_PLAN.md
@@ -295,8 +295,8 @@ resources:
 
 ## Next Steps
 
-- [ ] Phase 1: Create Dockerfile and .dockerignore
-- [ ] Phase 1: Test local Docker build
+- [x] Phase 1: Create Dockerfile and .dockerignore
+- [x] Phase 1: Test local Docker build
 - [ ] Phase 2: Create K8s manifest files
 - [ ] Phase 3: Refactor config.go for env var support
 - [ ] Phase 4: Update CI/CD workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o tee-sniper cmd/tee-sniper/main.go
+
+# Runtime stage
+FROM alpine:3.21
+
+RUN apk --no-cache add ca-certificates tzdata
+WORKDIR /app
+COPY --from=builder /app/tee-sniper .
+
+ENTRYPOINT ["/app/tee-sniper"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ go build -o tee-sniper cmd/tee-sniper/main.go
 
 Download the latest binary from the [Releases](https://github.com/stebennett/tee-sniper/releases) page.
 
+### Using Docker
+
+Build and run using Docker:
+
+```bash
+# Build the image
+docker build -t tee-sniper .
+
+# Run with arguments
+docker run --rm \
+    -e TWILIO_ACCOUNT_SID="your-sid" \
+    -e TWILIO_AUTH_TOKEN="your-token" \
+    tee-sniper \
+    -u YOUR_USERNAME \
+    -p YOUR_PIN \
+    -b https://your-golf-course.com/ \
+    -d 7 \
+    -t 15:00 \
+    -e 17:00 \
+    -f +1234567890 \
+    -n +0987654321
+```
+
 ## Configuration
 
 ### Environment Variables


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile using `golang:1.25-alpine` for building and `alpine:3.21` for runtime
- Add `.dockerignore` to exclude git, env files, markdown, testdata, and GitHub workflows from build context
- Update README with Docker build and run instructions
- Mark Phase 1 tasks complete in `DOCKER_K8S_PLAN.md`

## Details

**Dockerfile features:**
- Multi-stage build reduces image from ~800MB to ~26MB
- Includes `ca-certificates` for HTTPS connections (booking site, Twilio API)
- Includes `tzdata` for proper timezone handling
- CGO disabled for fully static binary
- Uses `-ldflags="-s -w"` to strip debug info

**Usage:**
```bash
docker build -t tee-sniper .
docker run --rm \
    -e TWILIO_ACCOUNT_SID="..." \
    -e TWILIO_AUTH_TOKEN="..." \
    tee-sniper -u USER -p PIN -b https://example.com/ -d 7 -t 15:00 -e 17:00 -f +1234 -n +5678
```

## Test plan

- [x] Docker build completes successfully
- [x] Container runs and displays help with `-h` flag
- [x] Image size verified (~26MB)
- [x] All existing Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)