### PR TITLE
Add Helm chart for Kubernetes/ArgoCD deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ Pre-built images are available from GitHub Container Registry:
 docker pull ghcr.io/stebennett/tee-sniper:latest
 ```
 
+### Kubernetes with Helm
+
+Deploy to Kubernetes as a CronJob using the included Helm chart:
+
+```bash
+# Install with Helm
+helm install tee-sniper ./helm/tee-sniper \
+    --namespace tee-sniper \
+    --create-namespace \
+    --set config.baseUrl="https://your-golf-course.com/" \
+    --set secrets.username="your-username" \
+    --set secrets.pin="your-pin" \
+    --set secrets.fromNumber="+1234567890" \
+    --set secrets.toNumber="+0987654321" \
+    --set secrets.twilioAccountSid="ACxxxx" \
+    --set secrets.twilioAuthToken="your-token"
+```
+
+For ArgoCD deployment, see the example manifests in `argocd/`. Full Helm chart documentation is available in [`helm/tee-sniper/README.md`](helm/tee-sniper/README.md).
+
 ## Configuration
 
 ### Environment Variables
@@ -222,6 +242,14 @@ tee-sniper/
 │   └── teetimes/
 │       ├── teetimes.go       # Tee time filtering and selection logic
 │       └── teetimes_test.go
+├── helm/
+│   └── tee-sniper/           # Helm chart for Kubernetes deployment
+│       ├── Chart.yaml
+│       ├── values.yaml
+│       └── templates/
+├── argocd/                   # ArgoCD Application examples
+│   ├── application.yaml
+│   └── secrets-example.yaml
 ├── testdata/                 # HTML fixtures for testing
 ├── .github/workflows/
 │   ├── build.yml             # CI build and test workflow

--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -1,0 +1,101 @@
+# Example ArgoCD Application manifest for tee-sniper
+#
+# This manifest deploys tee-sniper as a CronJob to your Kubernetes cluster.
+#
+# Prerequisites:
+# 1. ArgoCD installed in your cluster
+# 2. Secrets configured (see secrets-example.yaml or use external secret management)
+#
+# Usage:
+#   kubectl apply -f application.yaml -n argocd
+#
+# For production deployments, consider:
+# - Using Sealed Secrets or External Secrets Operator for credentials
+# - Storing values in a separate private repository
+# - Using ArgoCD ApplicationSets for multi-environment deployments
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tee-sniper
+  namespace: argocd
+  # Finalizer ensures proper cleanup when the Application is deleted
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    # Repository containing the Helm chart
+    repoURL: https://github.com/stebennett/tee-sniper.git
+    targetRevision: HEAD
+    path: helm/tee-sniper
+
+    # Helm-specific configuration
+    helm:
+      # Release name
+      releaseName: tee-sniper
+
+      # Values file from the repository (optional)
+      # valueFiles:
+      #   - values-production.yaml
+
+      # Inline values (override values.yaml)
+      values: |
+        schedule: "0 8 * * 1"  # Every Monday at 8:00 AM UTC
+
+        config:
+          daysAhead: 7
+          timeStart: "14:00"
+          timeEnd: "16:30"
+          baseUrl: "https://your-golf-course.com/"
+          retries: 5
+          dryRun: false
+
+        # For production, set secrets.create: false and use existingSecret
+        # with External Secrets Operator or Sealed Secrets
+        secrets:
+          create: false
+
+        existingSecret: "tee-sniper-credentials"
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+
+  destination:
+    # Target cluster (use https://kubernetes.default.svc for in-cluster)
+    server: https://kubernetes.default.svc
+    # Target namespace
+    namespace: tee-sniper
+
+  syncPolicy:
+    # Automated sync configuration
+    automated:
+      # Automatically prune resources that are no longer defined
+      prune: true
+      # Automatically sync when changes are detected
+      selfHeal: true
+      # Allow empty resources (useful for conditional templates)
+      allowEmpty: false
+
+    # Sync options
+    syncOptions:
+      # Create namespace if it doesn't exist
+      - CreateNamespace=true
+      # Apply out of sync resources only
+      - ApplyOutOfSyncOnly=true
+      # Server-side apply for better conflict resolution
+      - ServerSideApply=true
+
+    # Retry configuration for failed syncs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/secrets-example.yaml
+++ b/argocd/secrets-example.yaml
@@ -1,0 +1,49 @@
+# Example Secret manifest for tee-sniper
+#
+# WARNING: Do NOT commit this file with real credentials!
+# This is a template showing the required secret structure.
+#
+# For production, use one of these approaches:
+#
+# 1. Sealed Secrets (recommended for GitOps):
+#    kubeseal --format yaml < secrets.yaml > sealed-secrets.yaml
+#
+# 2. External Secrets Operator:
+#    Create an ExternalSecret that pulls from AWS Secrets Manager,
+#    HashiCorp Vault, or other secret stores.
+#
+# 3. ArgoCD Vault Plugin:
+#    Use inline placeholders that ArgoCD resolves from Vault.
+#
+# 4. Manual creation:
+#    kubectl create secret generic tee-sniper-credentials \
+#      --from-literal=TS_USERNAME='your-username' \
+#      --from-literal=TS_PIN='your-pin' \
+#      --from-literal=TS_FROM_NUMBER='+1234567890' \
+#      --from-literal=TS_TO_NUMBER='+0987654321' \
+#      --from-literal=TWILIO_ACCOUNT_SID='ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
+#      --from-literal=TWILIO_AUTH_TOKEN='your-auth-token' \
+#      -n tee-sniper
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tee-sniper-credentials
+  namespace: tee-sniper
+  labels:
+    app.kubernetes.io/name: tee-sniper
+    app.kubernetes.io/managed-by: manual
+type: Opaque
+stringData:
+  # Booking site credentials
+  TS_USERNAME: "your-username"
+  TS_PIN: "your-pin"
+
+  # Twilio phone numbers (E.164 format)
+  TS_FROM_NUMBER: "+1234567890"
+  TS_TO_NUMBER: "+0987654321"
+
+  # Twilio API credentials
+  # Get these from https://console.twilio.com/
+  TWILIO_ACCOUNT_SID: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  TWILIO_AUTH_TOKEN: "your-auth-token"

--- a/helm/tee-sniper/.helmignore
+++ b/helm/tee-sniper/.helmignore
@@ -1,0 +1,32 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Example values files (contain placeholder credentials)
+values-example.yaml
+values-dryrun.yaml
+
+# Documentation
+README.md

--- a/helm/tee-sniper/Chart.yaml
+++ b/helm/tee-sniper/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: tee-sniper
+description: A Helm chart for deploying tee-sniper golf booking automation as a Kubernetes CronJob
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - golf
+  - booking
+  - automation
+  - cronjob
+home: https://github.com/stebennett/tee-sniper
+sources:
+  - https://github.com/stebennett/tee-sniper
+maintainers:
+  - name: stebennett

--- a/helm/tee-sniper/README.md
+++ b/helm/tee-sniper/README.md
@@ -1,0 +1,221 @@
+# tee-sniper Helm Chart
+
+A Helm chart for deploying tee-sniper golf booking automation as a Kubernetes CronJob.
+
+## Overview
+
+This chart deploys tee-sniper as a CronJob that runs on a configurable schedule to automatically book golf tee times. The application:
+
+- Logs into a golf course booking website
+- Searches for available tee times within your specified time range
+- Books a randomly selected available slot
+- Sends SMS confirmation via Twilio
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Helm 3.0+
+- Twilio account for SMS notifications
+- Golf course booking website credentials
+
+## Installation
+
+### Quick Start
+
+```bash
+# Add your credentials via --set flags
+helm install tee-sniper ./helm/tee-sniper \
+  --namespace tee-sniper \
+  --create-namespace \
+  --set config.baseUrl="https://your-golf-course.com/" \
+  --set secrets.username="your-username" \
+  --set secrets.pin="your-pin" \
+  --set secrets.fromNumber="+1234567890" \
+  --set secrets.toNumber="+0987654321" \
+  --set secrets.twilioAccountSid="ACxxxx" \
+  --set secrets.twilioAuthToken="your-token"
+```
+
+### Using a Values File
+
+```bash
+# Create your values file (do not commit secrets!)
+cp values.yaml my-values.yaml
+# Edit my-values.yaml with your configuration
+
+helm install tee-sniper ./helm/tee-sniper \
+  --namespace tee-sniper \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+### With External Secrets
+
+For production deployments, use external secret management:
+
+```bash
+# Create secret manually or via External Secrets Operator
+kubectl create secret generic tee-sniper-credentials \
+  --from-literal=TS_USERNAME='your-username' \
+  --from-literal=TS_PIN='your-pin' \
+  --from-literal=TS_FROM_NUMBER='+1234567890' \
+  --from-literal=TS_TO_NUMBER='+0987654321' \
+  --from-literal=TWILIO_ACCOUNT_SID='ACxxxx' \
+  --from-literal=TWILIO_AUTH_TOKEN='your-token' \
+  -n tee-sniper
+
+# Install chart without creating secrets
+helm install tee-sniper ./helm/tee-sniper \
+  --namespace tee-sniper \
+  --set secrets.create=false \
+  --set existingSecret=tee-sniper-credentials \
+  --set config.baseUrl="https://your-golf-course.com/"
+```
+
+## Configuration
+
+### Image Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Container image repository | `ghcr.io/stebennett/tee-sniper` |
+| `image.tag` | Container image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+
+### Schedule Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `schedule` | Cron expression for job schedule | `0 8 * * 1` (Monday 8AM UTC) |
+
+### Application Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.daysAhead` | Days ahead to search for tee time | `7` |
+| `config.timeStart` | Earliest booking time (HH:MM) | `14:00` |
+| `config.timeEnd` | Latest booking time (HH:MM) | `16:30` |
+| `config.baseUrl` | Golf course website base URL | `""` |
+| `config.retries` | Number of retry attempts | `5` |
+| `config.dryRun` | Dry run mode (no actual booking) | `false` |
+| `config.partners` | Comma-separated partner IDs | `""` |
+
+### Secrets Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `secrets.create` | Create Secret resource | `true` |
+| `secrets.username` | Booking site username | `""` |
+| `secrets.pin` | Booking site PIN | `""` |
+| `secrets.fromNumber` | Twilio sender phone number | `""` |
+| `secrets.toNumber` | SMS recipient phone number | `""` |
+| `secrets.twilioAccountSid` | Twilio account SID | `""` |
+| `secrets.twilioAuthToken` | Twilio auth token | `""` |
+| `existingSecret` | Name of existing secret (when `secrets.create=false`) | `""` |
+
+### Job Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `job.backoffLimit` | Retries before marking job failed | `1` |
+| `job.successfulJobsHistoryLimit` | Successful jobs to keep | `3` |
+| `job.failedJobsHistoryLimit` | Failed jobs to keep | `3` |
+| `job.startingDeadlineSeconds` | Deadline for starting the job | `300` |
+| `job.concurrencyPolicy` | Concurrency policy | `Forbid` |
+| `job.ttlSecondsAfterFinished` | TTL after job completion | `86400` |
+
+### Pod Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `pod.restartPolicy` | Pod restart policy | `Never` |
+| `pod.annotations` | Pod annotations | `{}` |
+| `pod.labels` | Additional pod labels | `{}` |
+| `pod.nodeSelector` | Node selector | `{}` |
+| `pod.tolerations` | Tolerations | `[]` |
+| `pod.affinity` | Affinity rules | `{}` |
+| `pod.securityContext` | Pod security context | See values.yaml |
+
+### Resource Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.requests.cpu` | CPU request | Not set |
+| `resources.requests.memory` | Memory request | Not set |
+| `resources.limits.cpu` | CPU limit | Not set |
+| `resources.limits.memory` | Memory limit | Not set |
+
+### Service Account Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.annotations` | Service account annotations | `{}` |
+| `serviceAccount.name` | Service account name | Auto-generated |
+
+## ArgoCD Deployment
+
+See the `argocd/` directory for example ArgoCD Application manifests.
+
+```bash
+# Deploy via ArgoCD
+kubectl apply -f argocd/application.yaml -n argocd
+```
+
+## Manual Job Trigger
+
+To manually trigger the job for testing:
+
+```bash
+# Create a one-off job from the CronJob
+kubectl create job --from=cronjob/tee-sniper manual-test -n tee-sniper
+
+# Watch the job
+kubectl logs -f job/manual-test -n tee-sniper
+
+# Clean up
+kubectl delete job manual-test -n tee-sniper
+```
+
+## Dry Run Mode
+
+Test your configuration without making actual bookings:
+
+```bash
+helm install tee-sniper ./helm/tee-sniper \
+  --namespace tee-sniper \
+  --create-namespace \
+  --set config.dryRun=true \
+  # ... other values
+```
+
+## Uninstallation
+
+```bash
+helm uninstall tee-sniper -n tee-sniper
+kubectl delete namespace tee-sniper
+```
+
+## Troubleshooting
+
+### View CronJob Status
+
+```bash
+kubectl get cronjobs -n tee-sniper
+kubectl describe cronjob tee-sniper -n tee-sniper
+```
+
+### View Job History
+
+```bash
+kubectl get jobs -n tee-sniper
+kubectl logs job/<job-name> -n tee-sniper
+```
+
+### Check Secret Configuration
+
+```bash
+kubectl get secret -n tee-sniper
+kubectl describe secret tee-sniper -n tee-sniper
+```

--- a/helm/tee-sniper/templates/_helpers.tpl
+++ b/helm/tee-sniper/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tee-sniper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tee-sniper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tee-sniper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tee-sniper.labels" -}}
+helm.sh/chart: {{ include "tee-sniper.chart" . }}
+{{ include "tee-sniper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tee-sniper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tee-sniper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tee-sniper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tee-sniper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "tee-sniper.secretName" -}}
+{{- if .Values.secrets.create }}
+{{- include "tee-sniper.fullname" . }}
+{{- else }}
+{{- .Values.existingSecret }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the configmap to use
+*/}}
+{{- define "tee-sniper.configMapName" -}}
+{{- include "tee-sniper.fullname" . }}
+{{- end }}

--- a/helm/tee-sniper/templates/configmap.yaml
+++ b/helm/tee-sniper/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tee-sniper.configMapName" . }}
+  labels:
+    {{- include "tee-sniper.labels" . | nindent 4 }}
+data:
+  TS_DAYS_AHEAD: {{ .Values.config.daysAhead | quote }}
+  TS_TIME_START: {{ .Values.config.timeStart | quote }}
+  TS_TIME_END: {{ .Values.config.timeEnd | quote }}
+  TS_BASEURL: {{ .Values.config.baseUrl | quote }}
+  TS_RETRIES: {{ .Values.config.retries | quote }}
+  TS_DRY_RUN: {{ .Values.config.dryRun | quote }}
+  {{- if .Values.config.partners }}
+  TS_PARTNERS: {{ .Values.config.partners | quote }}
+  {{- end }}

--- a/helm/tee-sniper/templates/cronjob.yaml
+++ b/helm/tee-sniper/templates/cronjob.yaml
@@ -1,0 +1,139 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tee-sniper.fullname" . }}
+  labels:
+    {{- include "tee-sniper.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: {{ .Values.job.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.job.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.job.failedJobsHistoryLimit }}
+  {{- if .Values.job.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.job.startingDeadlineSeconds }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "tee-sniper.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.job.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+      {{- end }}
+      backoffLimit: {{ .Values.job.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "tee-sniper.selectorLabels" . | nindent 12 }}
+            {{- with .Values.pod.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.pod.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "tee-sniper.serviceAccountName" . }}
+          restartPolicy: {{ .Values.pod.restartPolicy }}
+          {{- with .Values.pod.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- with .Values.container.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              env:
+                # Configuration from ConfigMap
+                - name: TS_DAYS_AHEAD
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_DAYS_AHEAD
+                - name: TS_TIME_START
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_TIME_START
+                - name: TS_TIME_END
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_TIME_END
+                - name: TS_BASEURL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_BASEURL
+                - name: TS_RETRIES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_RETRIES
+                - name: TS_DRY_RUN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_DRY_RUN
+                {{- if .Values.config.partners }}
+                - name: TS_PARTNERS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "tee-sniper.configMapName" . }}
+                      key: TS_PARTNERS
+                {{- end }}
+                # Credentials from Secret
+                - name: TS_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TS_USERNAME
+                - name: TS_PIN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TS_PIN
+                - name: TS_FROM_NUMBER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TS_FROM_NUMBER
+                - name: TS_TO_NUMBER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TS_TO_NUMBER
+                - name: TWILIO_ACCOUNT_SID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TWILIO_ACCOUNT_SID
+                - name: TWILIO_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "tee-sniper.secretName" . }}
+                      key: TWILIO_AUTH_TOKEN
+              {{- with .Values.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.pod.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.pod.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.pod.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/tee-sniper/templates/secret.yaml
+++ b/helm/tee-sniper/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tee-sniper.fullname" . }}
+  labels:
+    {{- include "tee-sniper.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  TS_USERNAME: {{ .Values.secrets.username | quote }}
+  TS_PIN: {{ .Values.secrets.pin | quote }}
+  TS_FROM_NUMBER: {{ .Values.secrets.fromNumber | quote }}
+  TS_TO_NUMBER: {{ .Values.secrets.toNumber | quote }}
+  TWILIO_ACCOUNT_SID: {{ .Values.secrets.twilioAccountSid | quote }}
+  TWILIO_AUTH_TOKEN: {{ .Values.secrets.twilioAuthToken | quote }}
+{{- end }}

--- a/helm/tee-sniper/templates/serviceaccount.yaml
+++ b/helm/tee-sniper/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tee-sniper.serviceAccountName" . }}
+  labels:
+    {{- include "tee-sniper.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/tee-sniper/values-dryrun.yaml
+++ b/helm/tee-sniper/values-dryrun.yaml
@@ -1,0 +1,48 @@
+# Dry run values file for testing tee-sniper
+#
+# Use this to test your deployment without making actual bookings:
+#   helm install tee-sniper-test ./helm/tee-sniper -f values-dryrun.yaml
+#
+# The job will:
+# - Log into the booking site
+# - Search for available tee times
+# - Select a time slot
+# - Log what would be booked (but not actually book)
+# - Skip sending SMS notification
+
+# Run every 5 minutes for testing (adjust as needed)
+schedule: "*/5 * * * *"
+
+config:
+  daysAhead: 7
+  timeStart: "06:00"
+  timeEnd: "20:00"
+  baseUrl: "https://your-golf-course.com/"
+  retries: 1
+
+  # DRY RUN MODE - no actual booking will be made
+  dryRun: true
+
+# You still need valid credentials to test login and search
+secrets:
+  create: true
+  username: "your-username"
+  pin: "your-pin"
+  fromNumber: "+1234567890"
+  toNumber: "+0987654321"
+  twilioAccountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  twilioAuthToken: "your-auth-token"
+
+# Minimal resources for testing
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+# Keep more job history for debugging
+job:
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5

--- a/helm/tee-sniper/values-example.yaml
+++ b/helm/tee-sniper/values-example.yaml
@@ -1,0 +1,60 @@
+# Example values file for tee-sniper
+#
+# Copy this file and fill in your actual values:
+#   cp values-example.yaml my-values.yaml
+#
+# WARNING: Never commit files containing real credentials!
+# Add your values file to .gitignore
+
+# CronJob schedule - when to run the booking
+# Examples:
+#   "0 8 * * 1"     - Every Monday at 8:00 AM UTC
+#   "0 7 * * 1-5"   - Weekdays at 7:00 AM UTC
+#   "30 6 * * *"    - Daily at 6:30 AM UTC
+schedule: "0 8 * * 1"
+
+# Application configuration
+config:
+  # How many days ahead to search for a tee time
+  daysAhead: 7
+
+  # Time range for acceptable tee times (24-hour format)
+  timeStart: "14:00"
+  timeEnd: "16:30"
+
+  # Your golf course booking website URL
+  baseUrl: "https://your-golf-course.com/"
+
+  # Number of retry attempts if booking fails
+  retries: 5
+
+  # Set to true to test without making actual bookings
+  dryRun: false
+
+  # Optional: comma-separated list of partner member IDs
+  # partners: "partner1,partner2"
+
+# Credentials - REPLACE WITH YOUR ACTUAL VALUES
+secrets:
+  create: true
+
+  # Booking site login credentials
+  username: "your-username"
+  pin: "your-pin"
+
+  # Twilio phone numbers (E.164 format: +1234567890)
+  fromNumber: "+1234567890"
+  toNumber: "+0987654321"
+
+  # Twilio API credentials (from https://console.twilio.com/)
+  twilioAccountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  twilioAuthToken: "your-auth-token"
+
+# Optional: Resource limits
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/helm/tee-sniper/values.yaml
+++ b/helm/tee-sniper/values.yaml
@@ -1,0 +1,121 @@
+# Default values for tee-sniper
+# This is a YAML-formatted file.
+
+# Image configuration
+image:
+  repository: ghcr.io/stebennett/tee-sniper
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Image pull secrets for private registries
+imagePullSecrets: []
+
+# CronJob schedule (cron expression)
+# Default: Every Monday at 8:00 AM UTC
+schedule: "0 8 * * 1"
+
+# Application configuration (non-sensitive)
+config:
+  # Days ahead to search for tee time
+  daysAhead: 7
+  # Earliest booking time (HH:MM format)
+  timeStart: "14:00"
+  # Latest booking time (HH:MM format)
+  timeEnd: "16:30"
+  # Golf course website base URL
+  baseUrl: ""
+  # Number of retry attempts
+  retries: 5
+  # Dry run mode (no actual booking)
+  dryRun: false
+  # Comma-separated list of partner IDs
+  partners: ""
+
+# Sensitive credentials
+# IMPORTANT: For production, use external secret management
+# (Sealed Secrets, External Secrets Operator, or ArgoCD Vault Plugin)
+secrets:
+  # Set to true to create the Secret resource
+  # Set to false if using external secret management
+  create: true
+  # Booking site credentials
+  username: ""
+  pin: ""
+  # Twilio phone numbers
+  fromNumber: ""
+  toNumber: ""
+  # Twilio API credentials
+  twilioAccountSid: ""
+  twilioAuthToken: ""
+
+# Existing secret name to use instead of creating one
+# Only used when secrets.create is false
+existingSecret: ""
+
+# Job configuration
+job:
+  # Number of retries before marking job as failed
+  backoffLimit: 1
+  # Number of successful job runs to keep
+  successfulJobsHistoryLimit: 3
+  # Number of failed job runs to keep
+  failedJobsHistoryLimit: 3
+  # Deadline in seconds for starting the job
+  startingDeadlineSeconds: 300
+  # Concurrency policy: Allow, Forbid, or Replace
+  concurrencyPolicy: Forbid
+  # Time to live after job completion (seconds)
+  ttlSecondsAfterFinished: 86400
+
+# Pod configuration
+pod:
+  # Pod restart policy (Never or OnFailure)
+  restartPolicy: Never
+  # Pod annotations
+  annotations: {}
+  # Pod labels
+  labels: {}
+  # Node selector
+  nodeSelector: {}
+  # Tolerations
+  tolerations: []
+  # Affinity rules
+  affinity: {}
+  # Security context for the pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+
+# Container configuration
+container:
+  # Security context for the container
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+# Resource requests and limits
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 256Mi
+
+# Service account configuration
+serviceAccount:
+  # Create a service account
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # Name of the service account (auto-generated if empty)
+  name: ""
+
+# Override the name of the chart
+nameOverride: ""
+fullnameOverride: ""


### PR DESCRIPTION
## Summary

- Add Helm chart in `helm/tee-sniper/` for deploying tee-sniper as a Kubernetes CronJob
- Add ArgoCD Application example manifests in `argocd/`
- Update README with Kubernetes deployment instructions

## Features

- **CronJob-based deployment**: Runs on configurable schedule (default: weekly)
- **Full configuration via values.yaml**: Image, schedule, app config, secrets, resources
- **Secret management**: Built-in Secret creation or external secret support (Sealed Secrets, ESO)
- **Security hardened**: Non-root user, read-only filesystem, dropped capabilities
- **ArgoCD ready**: Example Application manifest with auto-sync and retry policies

## Chart Structure

```
helm/tee-sniper/
├── Chart.yaml           # Chart metadata
├── values.yaml          # Default configuration
├── values-example.yaml  # Example with placeholders
├── values-dryrun.yaml   # Testing configuration
├── templates/
│   ├── _helpers.tpl     # Template functions
│   ├── cronjob.yaml     # CronJob resource
│   ├── configmap.yaml   # Non-sensitive config
│   ├── secret.yaml      # Credentials
│   └── serviceaccount.yaml
└── README.md            # Chart documentation

argocd/
├── application.yaml     # ArgoCD Application example
└── secrets-example.yaml # Secret template for manual creation
```

## Test plan

- [x] Helm lint passes
- [x] Helm template renders valid YAML
- [x] Go tests still pass
- [ ] Manual test deployment to Kubernetes cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)