### PR TITLE
Fix gzip decompression and fail fast on login failure

### DIFF
--- a/cmd/tee-sniper/main.go
+++ b/cmd/tee-sniper/main.go
@@ -69,8 +69,11 @@ func (a *App) Run() error {
 	if err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
+	if !ok {
+		return fmt.Errorf("login failed: invalid credentials or unexpected response")
+	}
 
-	slog.Info("login completed", slog.Bool("success", ok))
+	slog.Info("login completed")
 
 	nextBookableDate := a.Clock.Now().AddDate(0, 0, a.Config.DaysAhead)
 	dateStr := nextBookableDate.Format("02-01-2006")

--- a/cmd/tee-sniper/main_test.go
+++ b/cmd/tee-sniper/main_test.go
@@ -139,6 +139,21 @@ func TestRunLoginError(t *testing.T) {
 	assert.Contains(t, err.Error(), "login failed")
 }
 
+func TestRunLoginUnsuccessful(t *testing.T) {
+	app, mockBooking, _, ctrl := createTestApp(t, defaultTestConfig(), time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC))
+	defer ctrl.Finish()
+
+	mockBooking.EXPECT().
+		Login("testuser", "1234").
+		Return(false, nil)
+
+	err := app.Run()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "login failed")
+	assert.Contains(t, err.Error(), "invalid credentials or unexpected response")
+}
+
 func TestRunGetAvailabilityError(t *testing.T) {
 	app, mockBooking, _, ctrl := createTestApp(t, defaultTestConfig(), time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC))
 	defer ctrl.Finish()

--- a/pkg/clients/bookingclient.go
+++ b/pkg/clients/bookingclient.go
@@ -58,7 +58,10 @@ func (w *BookingClient) addBrowserHeaders(req *http.Request) {
 	req.Header.Set("User-Agent", w.userAgent)
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
-	req.Header.Set("Accept-Encoding", "gzip, deflate")
+	// Note: Do NOT set Accept-Encoding manually. Go's HTTP client handles
+	// gzip decompression automatically when this header is absent. Setting it
+	// explicitly disables automatic decompression, causing compressed responses
+	// to be passed as raw bytes to goquery, which then finds no elements.
 	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("Upgrade-Insecure-Requests", "1")
 }
@@ -134,6 +137,11 @@ func (w BookingClient) Login(username string, password string) (bool, error) {
 	}
 
 	pageTitle := doc.Find("title").Text()
+	slog.Debug("login response",
+		slog.String("page_title", pageTitle),
+		slog.Int("status_code", resp.StatusCode),
+		slog.String("content_encoding", resp.Header.Get("Content-Encoding")),
+	)
 	return strings.HasPrefix(pageTitle, "Welcome"), nil
 }
 
@@ -160,6 +168,12 @@ func (w BookingClient) GetCourseAvailability(dateStr string) ([]models.TimeSlot,
 
 	defer resp.Body.Close()
 
+	slog.Debug("availability response",
+		slog.Int("status_code", resp.StatusCode),
+		slog.String("content_encoding", resp.Header.Get("Content-Encoding")),
+		slog.String("content_type", resp.Header.Get("Content-Type")),
+	)
+
 	if resp.StatusCode != 200 {
 		return slots, fmt.Errorf("invalid status code returned %d", resp.StatusCode)
 	}
@@ -168,6 +182,15 @@ func (w BookingClient) GetCourseAvailability(dateStr string) ([]models.TimeSlot,
 	if err != nil {
 		return slots, err
 	}
+
+	pageTitle := doc.Find("title").Text()
+	totalRows := doc.Find("tr").Length()
+	bookableRows := doc.Find("tr.bookable").Length()
+	slog.Debug("parsed availability page",
+		slog.String("page_title", pageTitle),
+		slog.Int("total_tr_elements", totalRows),
+		slog.Int("bookable_rows", bookableRows),
+	)
 
 	doc.Find("tr.bookable").Each(func(i int, s *goquery.Selection) {
 		bookingButton := s.Find("a.inlineBooking").Length() != 0

--- a/pkg/clients/bookingclient_test.go
+++ b/pkg/clients/bookingclient_test.go
@@ -787,7 +787,7 @@ func TestAddBrowserHeadersSetsAllHeaders(t *testing.T) {
 	assert.Contains(t, req.Header.Get("User-Agent"), "Mozilla")
 	assert.Equal(t, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", req.Header.Get("Accept"))
 	assert.Equal(t, "en-US,en;q=0.5", req.Header.Get("Accept-Language"))
-	assert.Equal(t, "gzip, deflate", req.Header.Get("Accept-Encoding"))
+	assert.Empty(t, req.Header.Get("Accept-Encoding"), "Accept-Encoding should not be set manually; Go handles gzip decompression automatically")
 	assert.Equal(t, "keep-alive", req.Header.Get("Connection"))
 	assert.Equal(t, "1", req.Header.Get("Upgrade-Insecure-Requests"))
 }


### PR DESCRIPTION
## Summary
- **Fix empty tee times**: Removed manual `Accept-Encoding: gzip, deflate` header from `addBrowserHeaders()`. In Go, setting this header explicitly disables automatic transparent decompression, so compressed responses were being passed as raw bytes to goquery, which found zero `tr.bookable` elements.
- **Fail fast on login failure**: `App.Run()` now returns an error immediately when `Login()` returns `false` (unsuccessful) instead of silently proceeding to search for tee times.
- **Debug logging**: Added debug-level logging to `Login` and `GetCourseAvailability` for page title, content-encoding, and parsed row counts to aid future troubleshooting.

## Test plan
- [x] Existing tests updated and passing
- [x] New `TestRunLoginUnsuccessful` test covers the `Login` returning `false, nil` case
- [x] Run app with `-l debug` to verify login succeeds and tee times are parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)