### PR TITLE
Add API client mode to Go CLI (Phase 6)

### DIFF
--- a/cmd/tee-sniper/main.go
+++ b/cmd/tee-sniper/main.go
@@ -208,10 +208,23 @@ func main() {
 
 	logger.Init(conf.LogLevel)
 
-	bookingClient, err := clients.NewBookingClient(conf.BaseUrl)
-	if err != nil {
-		slog.Error("failed to create booking client", slog.String("error", err.Error()))
+	if err := conf.Validate(); err != nil {
+		slog.Error("configuration error", slog.String("error", err.Error()))
 		os.Exit(1)
+	}
+
+	var bookingClient clients.BookingService
+	if conf.UseAPIMode() {
+		slog.Info("using API client mode", slog.String("api_url", conf.APIURL))
+		bookingClient = clients.NewAPIClient(conf.APIURL, conf.SharedSecret)
+	} else {
+		slog.Info("using direct booking client mode")
+		bc, err := clients.NewBookingClient(conf.BaseUrl)
+		if err != nil {
+			slog.Error("failed to create booking client", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+		bookingClient = bc
 	}
 
 	twilioClient := clients.NewTwilioClient()

--- a/pkg/clients/apiclient.go
+++ b/pkg/clients/apiclient.go
@@ -1,0 +1,292 @@
+package clients
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stebennett/tee-sniper/pkg/crypto"
+	"github.com/stebennett/tee-sniper/pkg/models"
+)
+
+// API request/response types
+
+type loginRequest struct {
+	Credentials string `json:"credentials"`
+}
+
+type loginResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
+type timeSlotResponse struct {
+	Time        string            `json:"time"`
+	CanBook     bool              `json:"can_book"`
+	BookingForm map[string]string `json:"booking_form"`
+}
+
+type availabilityResponse struct {
+	Date          string             `json:"date"`
+	Times         []timeSlotResponse `json:"times"`
+	FilteredCount int                `json:"filtered_count"`
+	TotalCount    int                `json:"total_count"`
+}
+
+type bookRequest struct {
+	NumSlots int  `json:"num_slots"`
+	DryRun   bool `json:"dry_run"`
+}
+
+type bookResponse struct {
+	BookingID   string `json:"booking_id"`
+	Date        string `json:"date"`
+	Time        string `json:"time"`
+	SlotsBooked int    `json:"slots_booked"`
+	Message     string `json:"message"`
+}
+
+type addPartnersRequest struct {
+	Partners []string `json:"partners"`
+	DryRun   bool     `json:"dry_run"`
+}
+
+type addPartnersResponse struct {
+	BookingID      string   `json:"booking_id"`
+	PartnersAdded  []string `json:"partners_added"`
+	PartnersFailed []string `json:"partners_failed"`
+	Message        string   `json:"message"`
+}
+
+type errorResponse struct {
+	Detail string `json:"detail"`
+}
+
+// APIClient implements BookingService by communicating with the tee-sniper API.
+type APIClient struct {
+	apiURL       string
+	sharedSecret string
+	httpClient   *http.Client
+	accessToken  string
+	lastDate     string   // YYYY-MM-DD format, set by GetCourseAvailability
+	partners     []string // accumulated partners for current booking
+	lastBooking  string   // current booking ID for partner accumulation reset
+}
+
+// NewAPIClient creates a new API client.
+func NewAPIClient(apiURL, sharedSecret string) *APIClient {
+	return &APIClient{
+		apiURL:       strings.TrimRight(apiURL, "/"),
+		sharedSecret: sharedSecret,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Login authenticates with the API using encrypted credentials.
+func (c *APIClient) Login(username, password string) (bool, error) {
+	encrypted, err := crypto.EncryptCredentials(username, password, c.sharedSecret)
+	if err != nil {
+		return false, fmt.Errorf("failed to encrypt credentials: %w", err)
+	}
+
+	body, err := json.Marshal(loginRequest{Credentials: encrypted})
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal login request: %w", err)
+	}
+
+	resp, err := c.doRequest(http.MethodPost, "/api/login", body, false)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return false, c.readError(resp)
+	}
+
+	var loginResp loginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return false, fmt.Errorf("failed to decode login response: %w", err)
+	}
+
+	c.accessToken = loginResp.AccessToken
+	return true, nil
+}
+
+// GetCourseAvailability retrieves available tee times for the given date.
+// dateStr should be in DD-MM-YYYY format (as used by the Go CLI).
+func (c *APIClient) GetCourseAvailability(dateStr string) ([]models.TimeSlot, error) {
+	apiDate, err := convertDateFormat(dateStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert date format: %w", err)
+	}
+	c.lastDate = apiDate
+
+	path := fmt.Sprintf("/api/%s/times", apiDate)
+	resp, err := c.doRequest(http.MethodGet, path, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	var availResp availabilityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&availResp); err != nil {
+		return nil, fmt.Errorf("failed to decode availability response: %w", err)
+	}
+
+	slots := make([]models.TimeSlot, len(availResp.Times))
+	for i, t := range availResp.Times {
+		slots[i] = models.TimeSlot{
+			Time:        t.Time,
+			CanBook:     t.CanBook,
+			BookingForm: t.BookingForm,
+		}
+	}
+
+	return slots, nil
+}
+
+// BookTimeSlot books the specified time slot via the API.
+func (c *APIClient) BookTimeSlot(timeSlot models.TimeSlot, playingPartners []string, dryRun bool) (string, error) {
+	if c.lastDate == "" {
+		return "", fmt.Errorf("no date available: call GetCourseAvailability first")
+	}
+
+	path := fmt.Sprintf("/api/%s/time/%s/book", c.lastDate, timeSlot.Time)
+	body, err := json.Marshal(bookRequest{
+		NumSlots: len(playingPartners) + 1,
+		DryRun:   dryRun,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal book request: %w", err)
+	}
+
+	resp, err := c.doRequest(http.MethodPost, path, body, true)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", c.readError(resp)
+	}
+
+	var bookResp bookResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bookResp); err != nil {
+		return "", fmt.Errorf("failed to decode book response: %w", err)
+	}
+
+	// Reset partner accumulation for new booking
+	c.partners = nil
+	c.lastBooking = bookResp.BookingID
+
+	return bookResp.BookingID, nil
+}
+
+// AddPlayingPartner adds a playing partner to an existing booking.
+// Partners are accumulated and sent as a growing list to ensure correct slot assignment.
+func (c *APIClient) AddPlayingPartner(bookingID, partnerID string, slotNumber int, dryRun bool) error {
+	// Reset accumulation if booking ID changed
+	if bookingID != c.lastBooking {
+		c.partners = nil
+		c.lastBooking = bookingID
+	}
+
+	c.partners = append(c.partners, partnerID)
+
+	body, err := json.Marshal(addPartnersRequest{
+		Partners: c.partners,
+		DryRun:   dryRun,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal add partners request: %w", err)
+	}
+
+	path := fmt.Sprintf("/api/bookings/%s", bookingID)
+	resp, err := c.doRequest(http.MethodPatch, path, body, true)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// 200 = all success, 207 = partial success (some previously added partners may fail on re-add)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusMultiStatus {
+		return c.readError(resp)
+	}
+
+	var partnersResp addPartnersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&partnersResp); err != nil {
+		return fmt.Errorf("failed to decode add partners response: %w", err)
+	}
+
+	// Only error if the newly added partner (the last one) failed
+	for _, failed := range partnersResp.PartnersFailed {
+		if failed == partnerID {
+			return fmt.Errorf("failed to add partner %s to booking %s", partnerID, bookingID)
+		}
+	}
+
+	return nil
+}
+
+// doRequest creates and executes an HTTP request to the API.
+func (c *APIClient) doRequest(method, path string, body []byte, auth bool) (*http.Response, error) {
+	url := c.apiURL + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if auth && c.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+// readError reads an error response from the API.
+func (c *APIClient) readError(resp *http.Response) error {
+	var errResp errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		return fmt.Errorf("API error (status %d)", resp.StatusCode)
+	}
+	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, errResp.Detail)
+}
+
+// convertDateFormat converts from DD-MM-YYYY to YYYY-MM-DD.
+func convertDateFormat(dateStr string) (string, error) {
+	t, err := time.Parse("02-01-2006", dateStr)
+	if err != nil {
+		return "", err
+	}
+	return t.Format("2006-01-02"), nil
+}

--- a/pkg/clients/apiclient_test.go
+++ b/pkg/clients/apiclient_test.go
@@ -1,0 +1,304 @@
+package clients
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stebennett/tee-sniper/pkg/crypto"
+	"github.com/stebennett/tee-sniper/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSharedSecret = "test-shared-secret"
+
+func TestAPIClientLogin_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/login", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req loginRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Verify we can decrypt the credentials
+		username, pin, err := crypto.DecryptCredentials(req.Credentials, testSharedSecret)
+		require.NoError(t, err)
+		assert.Equal(t, "testuser", username)
+		assert.Equal(t, "1234", pin)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(loginResponse{
+			AccessToken: "test-token-123",
+			ExpiresAt:   "2026-03-30T12:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	ok, err := client.Login("testuser", "1234")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "test-token-123", client.accessToken)
+}
+
+func TestAPIClientLogin_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(errorResponse{Detail: "invalid credentials"})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	ok, err := client.Login("baduser", "wrong")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAPIClientLogin_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errorResponse{Detail: "internal error"})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	_, err := client.Login("user", "pin")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestAPIClientGetCourseAvailability(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/2026-04-05/times", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(availabilityResponse{
+			Date: "2026-04-05",
+			Times: []timeSlotResponse{
+				{Time: "08:00", CanBook: true, BookingForm: map[string]string{"key": "val"}},
+				{Time: "09:30", CanBook: false, BookingForm: map[string]string{}},
+			},
+			FilteredCount: 2,
+			TotalCount:    10,
+		})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+
+	slots, err := client.GetCourseAvailability("05-04-2026")
+	require.NoError(t, err)
+	require.Len(t, slots, 2)
+
+	assert.Equal(t, "08:00", slots[0].Time)
+	assert.True(t, slots[0].CanBook)
+	assert.Equal(t, map[string]string{"key": "val"}, slots[0].BookingForm)
+
+	assert.Equal(t, "09:30", slots[1].Time)
+	assert.False(t, slots[1].CanBook)
+
+	// Verify lastDate was stored
+	assert.Equal(t, "2026-04-05", client.lastDate)
+}
+
+func TestAPIClientGetCourseAvailability_InvalidDate(t *testing.T) {
+	client := NewAPIClient("http://localhost", testSharedSecret)
+	_, err := client.GetCourseAvailability("invalid-date")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "convert date")
+}
+
+func TestAPIClientBookTimeSlot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/2026-04-05/time/10:00/book", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		var req bookRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, 3, req.NumSlots)
+		assert.True(t, req.DryRun)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(bookResponse{
+			BookingID:   "booking-456",
+			Date:        "2026-04-05",
+			Time:        "10:00",
+			SlotsBooked: 3,
+			Message:     "Successfully booked tee time",
+		})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+	client.lastDate = "2026-04-05"
+
+	slot := models.TimeSlot{Time: "10:00", CanBook: true}
+	partners := []string{"p1", "p2"}
+	bookingID, err := client.BookTimeSlot(slot, partners, true)
+
+	require.NoError(t, err)
+	assert.Equal(t, "booking-456", bookingID)
+	assert.Equal(t, "booking-456", client.lastBooking)
+	assert.Nil(t, client.partners) // reset on new booking
+}
+
+func TestAPIClientBookTimeSlot_NoDate(t *testing.T) {
+	client := NewAPIClient("http://localhost", testSharedSecret)
+	_, err := client.BookTimeSlot(models.TimeSlot{Time: "10:00"}, nil, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no date available")
+}
+
+func TestAPIClientAddPlayingPartner(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/bookings/booking-789", r.URL.Path)
+
+		var req addPartnersRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch callCount {
+		case 1:
+			// First call: single partner
+			assert.Equal(t, []string{"partner1"}, req.Partners)
+			assert.False(t, req.DryRun)
+			json.NewEncoder(w).Encode(addPartnersResponse{
+				BookingID:     "booking-789",
+				PartnersAdded: []string{"partner1"},
+			})
+		case 2:
+			// Second call: accumulated list
+			assert.Equal(t, []string{"partner1", "partner2"}, req.Partners)
+			w.WriteHeader(http.StatusMultiStatus)
+			json.NewEncoder(w).Encode(addPartnersResponse{
+				BookingID:      "booking-789",
+				PartnersAdded:  []string{"partner2"},
+				PartnersFailed: []string{"partner1"}, // already added, harmless failure
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+	client.lastBooking = "booking-789"
+
+	// First partner
+	err := client.AddPlayingPartner("booking-789", "partner1", 2, false)
+	require.NoError(t, err)
+
+	// Second partner - accumulates
+	err = client.AddPlayingPartner("booking-789", "partner2", 3, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, callCount)
+}
+
+func TestAPIClientAddPlayingPartner_NewPartnerFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMultiStatus)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(addPartnersResponse{
+			BookingID:      "booking-789",
+			PartnersAdded:  []string{},
+			PartnersFailed: []string{"badpartner"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+	client.lastBooking = "booking-789"
+
+	err := client.AddPlayingPartner("booking-789", "badpartner", 2, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to add partner badpartner")
+}
+
+func TestAPIClientAddPlayingPartner_ResetsOnNewBooking(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req addPartnersRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Should only have one partner since booking ID changed
+		assert.Len(t, req.Partners, 1)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(addPartnersResponse{
+			BookingID:     "booking-new",
+			PartnersAdded: req.Partners,
+		})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+	client.lastBooking = "booking-old"
+	client.partners = []string{"old-partner"}
+
+	err := client.AddPlayingPartner("booking-new", "new-partner", 2, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new-partner"}, client.partners)
+}
+
+func TestAPIClientAddPlayingPartner_AllFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(errorResponse{Detail: "Failed to add any partners"})
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(server.URL, testSharedSecret)
+	client.accessToken = "test-token"
+	client.lastBooking = "booking-789"
+
+	err := client.AddPlayingPartner("booking-789", "partner1", 2, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+}
+
+func TestConvertDateFormat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		hasError bool
+	}{
+		{"05-04-2026", "2026-04-05", false},
+		{"31-12-2025", "2025-12-31", false},
+		{"01-01-2026", "2026-01-01", false},
+		{"invalid", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := convertDateFormat(tt.input)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAPIClientTrailingSlash(t *testing.T) {
+	client := NewAPIClient("http://localhost:8000/", testSharedSecret)
+	assert.Equal(t, "http://localhost:8000", client.apiURL)
+}

--- a/pkg/clients/interfaces.go
+++ b/pkg/clients/interfaces.go
@@ -6,6 +6,7 @@ import "github.com/stebennett/tee-sniper/pkg/models"
 
 // Compile-time verification that concrete types implement interfaces
 var _ BookingService = (*BookingClient)(nil)
+var _ BookingService = (*APIClient)(nil)
 var _ SMSService = (*TwilioClient)(nil)
 
 // BookingService defines the interface for booking operations.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	flags "github.com/jessevdk/go-flags"
@@ -21,7 +22,10 @@ type Config struct {
 
 	Username string `short:"u" long:"username" env:"TS_USERNAME" required:"true" description:"The username to use for booking"`
 	Pin      string `short:"p" long:"pin" env:"TS_PIN" required:"true" description:"The pin associated with the username for booking"`
-	BaseUrl  string `short:"b" long:"baseurl" env:"TS_BASEURL" required:"true" description:"The host for the booking website"`
+	BaseUrl  string `short:"b" long:"baseurl" env:"TS_BASEURL" description:"The host for the booking website"`
+
+	APIURL       string `long:"api-url" env:"TS_API_URL" description:"API base URL (enables API client mode)"`
+	SharedSecret string `long:"shared-secret" env:"TS_SHARED_SECRET" description:"Shared secret for API credential encryption"`
 
 	FromNumber      string `short:"f" long:"fromnumber" env:"TS_FROM_NUMBER" required:"true" description:"The number to send the confirmation SMS from"`
 	ToNumber        string `short:"n" long:"tonumber" env:"TS_TO_NUMBER" required:"true" description:"The number to send the confirmation SMS to"`
@@ -41,6 +45,22 @@ func GetConfig() (Config, error) {
 	}
 
 	return c, nil
+}
+
+// UseAPIMode returns true if API client mode is enabled.
+func (c Config) UseAPIMode() bool {
+	return c.APIURL != ""
+}
+
+// Validate checks that the configuration is valid.
+func (c Config) Validate() error {
+	if c.APIURL != "" && c.SharedSecret == "" {
+		return fmt.Errorf("--shared-secret is required when using --api-url")
+	}
+	if c.APIURL == "" && c.BaseUrl == "" {
+		return fmt.Errorf("--baseurl is required when not using --api-url")
+	}
+	return nil
 }
 
 func (c Config) GetPlayingPartnersList() []string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -320,6 +320,64 @@ func TestGetConfigCliArgsOverrideEnvVars(t *testing.T) {
 	assert.Equal(t, "envuser", cfg.Username, "Env var should be used when CLI arg not provided")
 }
 
+func TestUseAPIMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiURL   string
+		expected bool
+	}{
+		{name: "empty api url returns false", apiURL: "", expected: false},
+		{name: "set api url returns true", apiURL: "http://localhost:8000", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{APIURL: tt.apiURL}
+			assert.Equal(t, tt.expected, cfg.UseAPIMode())
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Config
+		expectErr string
+	}{
+		{
+			name:      "direct mode with baseurl is valid",
+			cfg:       Config{BaseUrl: "https://example.com"},
+			expectErr: "",
+		},
+		{
+			name:      "api mode with shared secret is valid",
+			cfg:       Config{APIURL: "http://localhost:8000", SharedSecret: "secret"},
+			expectErr: "",
+		},
+		{
+			name:      "api mode without shared secret is invalid",
+			cfg:       Config{APIURL: "http://localhost:8000"},
+			expectErr: "--shared-secret is required when using --api-url",
+		},
+		{
+			name:      "direct mode without baseurl is invalid",
+			cfg:       Config{},
+			expectErr: "--baseurl is required when not using --api-url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectErr)
+			}
+		})
+	}
+}
+
 func TestGetConfigDryRunEnvVar(t *testing.T) {
 	// Save original os.Args and restore after test
 	originalArgs := os.Args

--- a/pkg/crypto/encrypt.go
+++ b/pkg/crypto/encrypt.go
@@ -1,0 +1,79 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// EncryptCredentials encrypts username and pin using AES-256-GCM.
+// The output format matches the Python EncryptionService: base64(nonce + ciphertext).
+func EncryptCredentials(username, pin, sharedSecret string) (string, error) {
+	key := sha256.Sum256([]byte(sharedSecret))
+
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	plaintext := []byte(fmt.Sprintf("%s:%s", username, pin))
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+
+	// Prepend nonce to ciphertext, then base64 encode
+	combined := append(nonce, ciphertext...)
+	return base64.StdEncoding.EncodeToString(combined), nil
+}
+
+// DecryptCredentials decrypts a base64-encoded AES-256-GCM encrypted string.
+// Returns the username and pin.
+func DecryptCredentials(encrypted, sharedSecret string) (string, string, error) {
+	data, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decode base64: %w", err)
+	}
+
+	key := sha256.Sum256([]byte(sharedSecret))
+
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", "", fmt.Errorf("encrypted data too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decrypt: %w", err)
+	}
+
+	// Split on first ":" only to support usernames containing ":"
+	parts := strings.SplitN(string(plaintext), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid credential format")
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/pkg/crypto/encrypt_test.go
+++ b/pkg/crypto/encrypt_test.go
@@ -1,0 +1,77 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		pin      string
+		secret   string
+	}{
+		{
+			name:     "basic credentials",
+			username: "testuser",
+			pin:      "1234",
+			secret:   "my-shared-secret",
+		},
+		{
+			name:     "username with special characters",
+			username: "user@example.com",
+			pin:      "p@ss!w0rd",
+			secret:   "another-secret",
+		},
+		{
+			name:     "empty pin",
+			username: "user",
+			pin:      "",
+			secret:   "secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, err := EncryptCredentials(tt.username, tt.pin, tt.secret)
+			require.NoError(t, err)
+			assert.NotEmpty(t, encrypted)
+
+			username, pin, err := DecryptCredentials(encrypted, tt.secret)
+			require.NoError(t, err)
+			assert.Equal(t, tt.username, username)
+			assert.Equal(t, tt.pin, pin)
+		})
+	}
+}
+
+func TestEncryptProducesDifferentCiphertexts(t *testing.T) {
+	enc1, err := EncryptCredentials("user", "pin", "secret")
+	require.NoError(t, err)
+
+	enc2, err := EncryptCredentials("user", "pin", "secret")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, enc1, enc2, "different nonces should produce different ciphertexts")
+}
+
+func TestDecryptWithWrongSecret(t *testing.T) {
+	encrypted, err := EncryptCredentials("user", "pin", "correct-secret")
+	require.NoError(t, err)
+
+	_, _, err = DecryptCredentials(encrypted, "wrong-secret")
+	assert.Error(t, err)
+}
+
+func TestDecryptInvalidBase64(t *testing.T) {
+	_, _, err := DecryptCredentials("not-valid-base64!!!", "secret")
+	assert.Error(t, err)
+}
+
+func TestDecryptTruncatedData(t *testing.T) {
+	_, _, err := DecryptCredentials("AQID", "secret") // 3 bytes, too short for nonce
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Add `APIClient` implementing `BookingService` interface to communicate with the tee-sniper API instead of direct site scraping
- Add AES-256-GCM encryption (`pkg/crypto`) matching the Python API's `EncryptionService`
- Add `--api-url` and `--shared-secret` config flags; direct mode remains the default when `--api-url` is absent
- Partner accumulation strategy ensures correct slot assignment when calling the batch PATCH endpoint one partner at a time

## Test plan
- [x] `go test ./...` — all existing and new tests pass
- [x] `go build ./cmd/tee-sniper/` — compiles cleanly
- [x] `go run cmd/tee-sniper/main.go -h` — shows new `--api-url` and `--shared-secret` flags
- [ ] Verify direct mode (no `--api-url`) works identically to current behavior
- [ ] Verify API mode with a running API server

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)