### PR TITLE
Plan: release tee-sniper-mcp as a wheel + sdist on GitHub Releases

### DIFF
--- a/.github/workflows/mcp-build.yml
+++ b/.github/workflows/mcp-build.yml
@@ -94,5 +94,7 @@ jobs:
           file: ./mcp/Dockerfile
           push: false
           tags: tee-sniper-mcp:${{ github.sha }}
+          build-args: |
+            VERSION=0.0.0+ci.${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/mcp-build.yml
+++ b/.github/workflows/mcp-build.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -36,11 +39,50 @@ jobs:
           cd mcp
           uv run pytest -v
 
+  wheel:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel + sdist
+        run: |
+          cd mcp
+          uv build
+
+      - name: Smoke-install wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --upgrade pip
+          /tmp/smoke/bin/pip install mcp/dist/*.whl
+          /tmp/smoke/bin/tee-sniper-mcp --version
+
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-dist-${{ github.sha }}
+          path: mcp/dist/*
+          retention-days: 7
+
   build:
     runs-on: ubuntu-latest
     needs: test
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -48,7 +90,8 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
-          context: ./mcp
+          context: .
+          file: ./mcp/Dockerfile
           push: false
           tags: tee-sniper-mcp:${{ github.sha }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,56 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.26'
 
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+
     - name: Get version from tag
       id: version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: |
+        echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        echo "VERSION_NUMBER=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
     - name: Build for Linux amd64
       run: |
         GOOS=linux GOARCH=amd64 go build -o tee-sniper-linux-amd64 ./cmd/tee-sniper
+
+    - name: Build MCP wheel + sdist
+      run: |
+        cd mcp
+        uv build
+
+    - name: Verify MCP wheel version matches tag
+      run: |
+        tag="${{ steps.version.outputs.VERSION_NUMBER }}"
+        whl=$(ls mcp/dist/*.whl)
+        case "$(basename "$whl")" in
+          tee_sniper_mcp-${tag}-*) echo "ok: $whl" ;;
+          *) echo "wheel $whl does not match tag $tag"; exit 1 ;;
+        esac
+
+    - name: Resolve MCP artefact paths
+      id: mcp_artefacts
+      run: |
+        wheel=$(ls mcp/dist/*.whl)
+        sdist=$(ls mcp/dist/*.tar.gz)
+        echo "wheel=${wheel}" >> "$GITHUB_OUTPUT"
+        echo "wheel_name=$(basename "${wheel}")" >> "$GITHUB_OUTPUT"
+        echo "sdist=${sdist}" >> "$GITHUB_OUTPUT"
+        echo "sdist_name=$(basename "${sdist}")" >> "$GITHUB_OUTPUT"
 
     - name: Create Release
       id: create_release
@@ -54,6 +91,26 @@ jobs:
         asset_path: ./tee-sniper-linux-amd64
         asset_name: tee-sniper-linux-amd64
         asset_content_type: application/octet-stream
+
+    - name: Upload MCP wheel
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.mcp_artefacts.outputs.wheel }}
+        asset_name: ${{ steps.mcp_artefacts.outputs.wheel_name }}
+        asset_content_type: application/zip
+
+    - name: Upload MCP sdist
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.mcp_artefacts.outputs.sdist }}
+        asset_name: ${{ steps.mcp_artefacts.outputs.sdist_name }}
+        asset_content_type: application/gzip
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -125,7 +182,8 @@ jobs:
     - name: Build and push MCP Docker image
       uses: docker/build-push-action@v7
       with:
-        context: ./mcp
+        context: .
+        file: ./mcp/Dockerfile
         push: true
         tags: ${{ steps.meta-mcp.outputs.tags }}
         labels: ${{ steps.meta-mcp.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,5 +187,7 @@ jobs:
         push: true
         tags: ${{ steps.meta-mcp.outputs.tags }}
         labels: ${{ steps.meta-mcp.outputs.labels }}
+        build-args: |
+          VERSION=${{ steps.version.outputs.VERSION_NUMBER }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ When implementing the Docker migration plan (see `docs/DOCKER_PLAN.md`):
 
 ### MCP Server (Local)
 
-**Location:** `mcp/` (Python 3.14 project, managed with `uv`, runnable via `uv run tee-sniper-mcp` or the `ghcr.io/<repo>-mcp` Docker image).
+**Location:** `mcp/` (Python 3.14 project, managed with `uv`, runnable via `uv run tee-sniper-mcp`, the `ghcr.io/<repo>-mcp` Docker image, or the `tee_sniper_mcp-<version>-py3-none-any.whl` attached to each `v*.*.*` GitHub Release — see `mcp/README.md` for install commands). Version is derived from the git tag via `hatch-vcs`.
 
 ```bash
 # Install + run mcp tests

--- a/docs/superpowers/plans/2026-05-09-mcp-wheel-release.md
+++ b/docs/superpowers/plans/2026-05-09-mcp-wheel-release.md
@@ -1,0 +1,247 @@
+# MCP Server Wheel Release Plan
+
+**Goal:** On every existing `v*.*.*` git tag, build `tee-sniper-mcp` as a Python
+wheel + sdist and attach the artefacts to the GitHub Release. MetaMCP and other
+clients install with `uv tool install` / `uvx` directly from the private-repo
+Release URL using a GitHub PAT, no separate index required.
+
+**Spec source:** answers to plan-clarification questions on
+`claude/plan-mcp-release-zPj8d`:
+
+- Format: Python wheel + sdist (no separate Docker release; existing GHCR build
+  in `release.yml` stays untouched).
+- Hosting: GitHub Releases (private repo, PAT-gated download).
+- Versioning: reuse existing `v*.*.*` tag — extend `release.yml`, do **not**
+  create an MCP-specific tag scheme.
+
+## Existing state (do not re-do)
+
+- `.github/workflows/release.yml` already runs on `v*.*.*`, creates the GitHub
+  Release, uploads the Go binary, and pushes three GHCR images
+  (`-`, `-api`, `-mcp`).
+- `mcp/pyproject.toml` uses hatchling with hardcoded `version = "0.1.0"`.
+- `mcp/Dockerfile` does `pip install .` from the source tree — version drift
+  there is invisible until released.
+- `.github/workflows/mcp-build.yml` runs `pytest` and a Docker build on PRs but
+  does **not** build the wheel.
+
+## Phase / PR workflow
+
+Per `CLAUDE.md`, each phase ships in its own PR. Phase 1 must merge before 2,
+3, and 4 — they all depend on dynamic versioning. Phases 2 and 3 are
+independent of each other; 4 depends on 3 having shipped at least one Release
+asset to point users at.
+
+---
+
+## Phase 1 — Dynamic versioning from git tag
+
+**Branch:** `mcp/release-phase1-dynamic-version`
+**Why:** the wheel filename and `tee_sniper_mcp.__version__` must reflect the
+tag the workflow is building, without manual `pyproject.toml` edits per
+release.
+
+### Tasks
+
+- [ ] **1.1 Add `hatch-vcs` to the build backend.** In `mcp/pyproject.toml`:
+  - `[build-system].requires` becomes `["hatchling", "hatch-vcs"]`.
+  - Replace `version = "0.1.0"` with `dynamic = ["version"]`.
+  - Add:
+    ```toml
+    [tool.hatch.version]
+    source = "vcs"
+    raw-options = { root = "..", tag-pattern = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$" }
+
+    [tool.hatch.build.hooks.vcs]
+    version-file = "src/tee_sniper_mcp/_version.py"
+    ```
+    `root = ".."` is required because `hatch-vcs` runs from `mcp/` but the
+    git repo root is one level up. The tag pattern only matches the existing
+    `v*.*.*` shape so unrelated tags (e.g. `mcp-vX.Y.Z`, RC tags) cannot
+    accidentally drive the version.
+- [ ] **1.2 Generated version file.** Add `src/tee_sniper_mcp/_version.py` to
+  `.gitignore` (the file is generated at build time). Update
+  `src/tee_sniper_mcp/__init__.py` to do
+  `from ._version import __version__` inside a try/except that falls back to
+  `"0.0.0+unknown"` when the file is absent (editable installs without a
+  build).
+- [ ] **1.3 Verify locally.**
+  - `cd mcp && uv build` — expect a `dist/tee_sniper_mcp-<dev-version>.tar.gz`
+    and matching `.whl`. Untagged HEAD should produce a PEP 440 dev version
+    like `0.1.0.dev3+g<sha>` (whatever the most recent matching tag is, plus
+    commit count).
+  - `uv run pytest -v` — must still pass.
+- [ ] **1.4 Update `mcp/Dockerfile` if needed.** `pip install .` requires git
+  history to be present in the build context for `hatch-vcs` to resolve the
+  version. The repo `.dockerignore` (verify; add one in `mcp/` if missing
+  that does NOT exclude `.git`) and the `docker build context` must include
+  `.git`. Easiest fix: change the GHCR Docker build in `release.yml` and
+  `mcp-build.yml` to use the **repo root** as build context with
+  `file: mcp/Dockerfile`, so `.git/` is available; update the Dockerfile
+  `COPY` paths to `mcp/pyproject.toml`, `mcp/README.md`, `mcp/src`. Confirm
+  `docker build -f mcp/Dockerfile .` succeeds locally and the resulting
+  image's `tee-sniper-mcp` reports a non-`0.0.0+unknown` version (add a
+  trivial `--version` flag if there isn't one — see 1.5).
+- [ ] **1.5 Optional but recommended: `--version` CLI flag.** Add a
+  `--version` argument to the `tee-sniper-mcp` entry point (`server.main`)
+  that prints `tee_sniper_mcp.__version__` and exits 0. Lets CI smoke-test the
+  installed wheel without importing.
+- [ ] **1.6 Commit + PR.** Single commit; PR title:
+  `mcp: derive package version from git tag via hatch-vcs`.
+
+### Risks / things to double-check
+
+- **`tag-pattern` regex.** Must use an actual regex (Python `re`), not a glob.
+  Test by tagging a throwaway commit `git tag v9.9.9 && cd mcp && uv build`
+  and confirming the wheel is named `tee_sniper_mcp-9.9.9-…`. Delete the tag
+  after.
+- **Dirty working tree.** `hatch-vcs` appends `.dirty` to versions built off a
+  dirty tree, which breaks PEP 440 wheel filenames in some toolchains. The
+  release workflow checks out a clean tag commit, so this is fine; just
+  document it for local dev.
+
+---
+
+## Phase 2 — CI wheel build on PRs
+
+**Branch:** `mcp/release-phase2-ci-wheel-smoke`
+**Why:** catch packaging regressions (missing files, broken
+`hatch-vcs` config) on every PR, before tagging.
+
+### Tasks
+
+- [ ] **2.1 Extend `.github/workflows/mcp-build.yml`.** Add a `wheel` job that
+  `needs: test` and runs after the existing test job:
+  - `actions/checkout@v6` with `fetch-depth: 0` and `fetch-tags: true` so
+    `hatch-vcs` can resolve a version. Untagged main builds will produce a
+    dev version — that is fine, we only assert that build succeeds.
+  - `astral-sh/setup-uv@v3` + `actions/setup-python@v6` (3.14) as in the
+    existing `test` job.
+  - `cd mcp && uv build`.
+  - Smoke-install: create a fresh venv, `uv pip install dist/*.whl`, run
+    `tee-sniper-mcp --version` (depends on 1.5; otherwise `python -c "import
+    tee_sniper_mcp; print(tee_sniper_mcp.__version__)"`).
+  - `actions/upload-artifact@v4` to retain the wheel + sdist for 7 days for
+    debugging — name `mcp-dist-${{ github.sha }}`.
+- [ ] **2.2 Verify the workflow on the PR itself.** The PR adding the job
+  should also exercise it. If the smoke step fails, fix Phase 1 issues
+  before merging.
+
+---
+
+## Phase 3 — Attach wheel + sdist to GitHub Release
+
+**Branch:** `mcp/release-phase3-release-artefacts`
+**Why:** the actual user-visible deliverable.
+
+### Tasks
+
+- [ ] **3.1 Patch `.github/workflows/release.yml`.**
+  - On the existing checkout step add `fetch-depth: 0` and
+    `fetch-tags: true` (required for `hatch-vcs` and a no-op for the Go
+    build).
+  - After `Set up Go` (or in a parallel preparatory block — order does not
+    matter as long as it runs before the upload steps) add:
+    - `actions/setup-python@v6` with `python-version: '3.14'`.
+    - `astral-sh/setup-uv@v3`.
+    - `Build MCP wheel + sdist`: `cd mcp && uv build`.
+  - Add two new `actions/upload-release-asset@v1` steps after the existing
+    "Upload Linux Binary" step, one for the wheel (`./mcp/dist/*.whl`) and
+    one for the sdist (`./mcp/dist/*.tar.gz`). Use a glob-resolving shell
+    step first to capture exact filenames into outputs (the deprecated
+    action does not glob):
+    ```yaml
+    - name: Resolve MCP artefact paths
+      id: mcp_artefacts
+      run: |
+        echo "wheel=$(ls mcp/dist/*.whl)" >> "$GITHUB_OUTPUT"
+        echo "sdist=$(ls mcp/dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+        echo "wheel_name=$(basename mcp/dist/*.whl)" >> "$GITHUB_OUTPUT"
+        echo "sdist_name=$(basename mcp/dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+    ```
+  - Use the `upload_url` from the existing `create_release` step for both
+    uploads. `asset_content_type`: `application/zip` for the wheel,
+    `application/gzip` for the sdist.
+- [ ] **3.2 Sanity-check the version against the tag.** Add a small step
+  before upload:
+  ```yaml
+  - name: Verify wheel version matches tag
+    run: |
+      tag="${GITHUB_REF#refs/tags/v}"
+      whl=$(ls mcp/dist/*.whl)
+      case "$whl" in
+        *tee_sniper_mcp-${tag}-*) echo "ok: $whl";;
+        *) echo "wheel $whl does not match tag $tag"; exit 1;;
+      esac
+  ```
+  Catches `hatch-vcs` mis-configuration the moment we tag, instead of
+  shipping a wrongly-named wheel.
+- [ ] **3.3 Test before tagging.** Verify on a throwaway branch via
+  `workflow_dispatch` (temporarily add `workflow_dispatch:` to the trigger
+  block on the test branch only — do **not** merge that), or push a
+  pre-release tag like `v0.1.0-test1` and confirm the wheel + sdist appear on
+  the resulting Release. Delete the test tag and Release after.
+  - **Note on the deprecation:** `actions/create-release@v1` and
+    `actions/upload-release-asset@v1` are unmaintained but still functional.
+    Migrating to `softprops/action-gh-release@v2` is **out of scope** —
+    captured in "Follow-ups" below.
+
+---
+
+## Phase 4 — Install docs for MetaMCP
+
+**Branch:** `mcp/release-phase4-docs`
+**Why:** users need to know the install command, and that they need a PAT.
+
+### Tasks
+
+- [ ] **4.1 Add "Install from GitHub Releases" section to `mcp/README.md`,
+  immediately after the existing "Running" section.** Cover:
+  - PAT requirement: GitHub PAT with `repo` scope (classic) or a fine-grained
+    PAT with `Contents: Read` on this repo. Private-repo Release assets are
+    PAT-gated.
+  - `uv tool install` against the asset URL using a token:
+    ```bash
+    uv tool install \
+      "https://${GH_TOKEN}@github.com/<owner>/tee-sniper/releases/download/v<X.Y.Z>/tee_sniper_mcp-<X.Y.Z>-py3-none-any.whl"
+    tee-sniper-mcp --version
+    ```
+  - One-shot via `uvx --from <url> tee-sniper-mcp` (no install).
+- [ ] **4.2 Update the "MetaMCP config" snippet in `mcp/README.md`.** Add a
+  second example using `uvx --from <wheel-url>` alongside the existing
+  Docker example, so MetaMCP installs that prefer a Python entry point can
+  use it. Make the PAT requirement explicit in the snippet's environment
+  block.
+- [ ] **4.3 Update `CLAUDE.md` MCP section.** One sentence noting that wheel
+  + sdist are attached to each `v*.*.*` GitHub Release alongside the Docker
+  image. Do **not** duplicate the install instructions — link to
+  `mcp/README.md`.
+- [ ] **4.4 No code changes.** Pure docs PR.
+
+---
+
+## Out of scope / follow-ups
+
+- Migrating `release.yml` from `actions/create-release@v1` +
+  `actions/upload-release-asset@v1` (both deprecated) to
+  `softprops/action-gh-release@v2`. Worth doing for the whole workflow at once
+  rather than piecemeal — track separately.
+- Publishing to a private PyPI-style index (CodeArtifact, Gemfury, self-hosted
+  devpi). Not needed unless we outgrow Release-asset distribution.
+- Signing wheels (PEP 740 / Sigstore).
+- Bumping the existing `0.1.0` baseline to `0.2.0` to mark the first
+  Release-shipped version cleanly. Cosmetic; decide at release time.
+
+## Verification checklist (run before declaring "shipped")
+
+- [ ] `cd mcp && uv build` on a clean checkout of the tag produces wheel and
+  sdist named `tee_sniper_mcp-<tag without v>.*`.
+- [ ] `uv tool install <wheel-url-with-token>` followed by
+  `tee-sniper-mcp --version` prints the tag's version.
+- [ ] `uvx --from <wheel-url-with-token> tee-sniper-mcp --help` works without
+  a prior install.
+- [ ] The Release page shows three new assets in addition to the Go binary:
+  the wheel, the sdist, and (unchanged) the Linux Go binary; GHCR shows the
+  three Docker tags as before.
+- [ ] `mcp-build.yml` wheel job is green on a non-tag PR (i.e. dev versioning
+  works).

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,5 @@
+src/tee_sniper_mcp/_version.py
+dist/
+*.egg-info/
+.venv/
+__pycache__/

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
-# Build context: repository root (so `.git/` is available for hatch-vcs).
-# Build with: docker build -f mcp/Dockerfile .
+# Build context: repository root.
+# Build with: docker build -f mcp/Dockerfile --build-arg VERSION=<x.y.z> .
+#
+# VERSION is forwarded to hatch-vcs via SETUPTOOLS_SCM_PRETEND_VERSION so the
+# image does not need .git/ available at build time.
 
 FROM python:3.14-slim AS builder
 
@@ -12,12 +15,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /build
 
-# git is needed by hatch-vcs to derive the version from tags at build time.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+ARG VERSION=0.0.0+unknown
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
-COPY .git ./.git
 COPY mcp/pyproject.toml mcp/README.md ./
 COPY mcp/src ./src
 

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,18 +1,39 @@
 # syntax=docker/dockerfile:1.7
 
-FROM python:3.14-slim AS base
+# Build context: repository root (so `.git/` is available for hatch-vcs).
+# Build with: docker build -f mcp/Dockerfile .
+
+FROM python:3.14-slim AS builder
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-WORKDIR /app
+WORKDIR /build
 
-COPY pyproject.toml README.md ./
-COPY src ./src
+# git is needed by hatch-vcs to derive the version from tags at build time.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install .
+COPY .git ./.git
+COPY mcp/pyproject.toml mcp/README.md ./
+COPY mcp/src ./src
+
+RUN pip install build \
+    && python -m build --wheel --outdir /wheels .
+
+FROM python:3.14-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+COPY --from=builder /wheels /wheels
+
+RUN pip install /wheels/*.whl && rm -rf /wheels
 
 USER 65532:65532
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -189,6 +189,8 @@ import of `session_manager.py`, which uses redis.
 - The console script is `tee_sniper_mcp.cli:main`; it answers `--version`
   before importing the FastMCP runtime stack.
 - The Docker image is multi-stage: the builder produces a wheel via
-  `python -m build` (so `hatch-vcs` can resolve a version from `.git/`), and
-  the runtime stage installs that wheel. Build context is the repo root —
-  `docker build -f mcp/Dockerfile .` from there.
+  `python -m build`, the runtime stage installs it. The version is supplied
+  by the `VERSION` build-arg (forwarded to `hatch-vcs` via
+  `SETUPTOOLS_SCM_PRETEND_VERSION`), so the image does not need `.git/` in
+  context. Build context is the repo root —
+  `docker build -f mcp/Dockerfile --build-arg VERSION=<x.y.z> .`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -62,6 +62,29 @@ uv sync
 uv run tee-sniper-mcp
 ```
 
+### Install from a GitHub Release
+
+Each `v*.*.*` tag publishes `tee_sniper_mcp-<version>-py3-none-any.whl` and a
+matching sdist as Release assets. Because this repo is private, you need a
+GitHub PAT with `Contents: Read` on the repo (classic PAT: `repo` scope; fine-
+grained: `Contents` read-only) to download them.
+
+```bash
+export GH_TOKEN=ghp_...
+VERSION=0.1.0
+WHEEL_URL="https://${GH_TOKEN}@github.com/<owner>/tee-sniper/releases/download/v${VERSION}/tee_sniper_mcp-${VERSION}-py3-none-any.whl"
+
+# persistent install
+uv tool install "${WHEEL_URL}"
+tee-sniper-mcp --version
+
+# or, one-shot via uvx (no install)
+uvx --from "${WHEEL_URL}" tee-sniper-mcp --version
+```
+
+`uv tool install` and `uvx` both require Python 3.14 available; uv will fetch
+it automatically.
+
 ### Via Docker
 
 ```bash
@@ -92,6 +115,8 @@ docker run --rm -i \
 
 ## MetaMCP config
 
+### Via Docker
+
 ```yaml
 servers:
   tee-sniper:
@@ -110,6 +135,27 @@ servers:
       - TSA_SHARED_SECRET
       - ghcr.io/<owner>/tee-sniper-mcp:latest
     env:
+      TSA_API_BASE_URL: http://api:8000
+      TSA_USERNAME: ...
+      TSA_PIN: ...
+      TSA_SHARED_SECRET: ...
+```
+
+### Via uvx (Release wheel)
+
+Substitute `<version>` and provide `GH_TOKEN` in the environment running
+MetaMCP (the URL embeds it for the download).
+
+```yaml
+servers:
+  tee-sniper:
+    command: uvx
+    args:
+      - --from
+      - https://${GH_TOKEN}@github.com/<owner>/tee-sniper/releases/download/v<version>/tee_sniper_mcp-<version>-py3-none-any.whl
+      - tee-sniper-mcp
+    env:
+      GH_TOKEN: ghp_...
       TSA_API_BASE_URL: http://api:8000
       TSA_USERNAME: ...
       TSA_PIN: ...
@@ -137,5 +183,12 @@ import of `session_manager.py`, which uses redis.
   `mcp.list_tools()`.
 - Configuration errors at startup exit with code 2 and print
   `tee-sniper-mcp: configuration error: …` to stderr.
-- The Docker image uses `pip install .` (no lock file), so transitive deps are
-  resolved at build time from the floor pins in `pyproject.toml`.
+- The package version is derived from the most recent `v*.*.*` git tag via
+  `hatch-vcs`. Untagged builds produce a PEP 440 dev version like
+  `0.1.dev3+g<sha>`; the build needs git history (`fetch-depth: 0`).
+- The console script is `tee_sniper_mcp.cli:main`; it answers `--version`
+  before importing the FastMCP runtime stack.
+- The Docker image is multi-stage: the builder produces a wheel via
+  `python -m build` (so `hatch-vcs` can resolve a version from `.git/`), and
+  the runtime stage installs that wheel. Build context is the repo root —
+  `docker build -f mcp/Dockerfile .` from there.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tee-sniper-mcp"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Local MCP server that exposes tee-sniper booking operations to LLM clients."
 requires-python = ">=3.14"
 readme = "README.md"
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-tee-sniper-mcp = "tee_sniper_mcp.server:main"
+tee-sniper-mcp = "tee_sniper_mcp.cli:main"
 
 [dependency-groups]
 dev = [
@@ -26,8 +26,15 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { root = "..", tag_regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$" }
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/tee_sniper_mcp/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tee_sniper_mcp"]

--- a/mcp/src/tee_sniper_mcp/__init__.py
+++ b/mcp/src/tee_sniper_mcp/__init__.py
@@ -1,3 +1,6 @@
 """Local stdio MCP server for tee-sniper."""
 
-__version__ = "0.1.0"
+try:
+    from tee_sniper_mcp._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"

--- a/mcp/src/tee_sniper_mcp/cli.py
+++ b/mcp/src/tee_sniper_mcp/cli.py
@@ -1,0 +1,21 @@
+"""Console-script entry point.
+
+Kept thin so that `tee-sniper-mcp --version` can answer without importing
+fastmcp / pydantic and the rest of the runtime stack.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from tee_sniper_mcp import __version__
+
+
+def main() -> None:
+    if any(arg in {"--version", "-V"} for arg in sys.argv[1:]):
+        print(__version__)
+        sys.exit(0)
+
+    from tee_sniper_mcp.server import main as server_main
+
+    server_main()

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -1013,7 +1013,6 @@ wheels = [
 
 [[package]]
 name = "tee-sniper-mcp"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Four-phase plan reusing the existing v*.*.* tag: switch mcp/pyproject.toml
to hatch-vcs for tag-driven versioning, add a wheel-build smoke step to
the PR CI, extend release.yml to attach the wheel and sdist to the GitHub
Release, then document install via uv tool install / uvx with a PAT for
MetaMCP.