### PR TITLE
Add wanted tee-times: persisted auto-booking requests

### DIFF
--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           TSA_REDIS_URL: redis://localhost:6379/0
           TSA_SHARED_SECRET: test-secret
+          # Fail loudly if the Redis service is unreachable instead of
+          # silently skipping the session integration tests.
+          TSA_REQUIRE_REDIS: "1"
         run: |
           cd api
           pytest --cov=app --cov-report=xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ cd api && .venv/bin/python -m pytest tests/ -v
 
 # Run specific Python test file
 cd api && .venv/bin/python -m pytest tests/test_booking_routes.py -v
+
+# Run the wanted-slot worker once (needs TSA_* env, see api/app/config.py)
+cd api && .venv/bin/python -m app.cli.worker
 ```
 
 ### Building
@@ -122,6 +125,19 @@ When implementing the API migration plan (see `docs/API_MIGRATION_PLAN.md`):
    - Push branch and create PR for review
    - Wait for PR to be reviewed and merged before starting next phase
 3. Completed phases: 1 (Foundation), 2 (Redis), 3 (Booking Client), 4 (API Endpoints)
+
+## Wanted Tee-Times
+
+Persisted auto-booking requests. Spec:
+`docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+Plan: `docs/superpowers/plans/2026-05-16-wanted-tee-times.md`.
+
+- Models: `api/app/models/wanted.py`
+- Store: `api/app/services/wanted_store.py` (Redis `wanted:{id}` + `wanted:index`)
+- Scheduling predicate: `api/app/services/scheduling.py` (`is_due`, 8-day window)
+- Worker: `api/app/services/worker.py` (`run_once`), CLI `app/cli/worker.py`
+- Router: `api/app/routers/wanted.py` (`/api/wanted`)
+- Deploy: opt-in `worker` CronJob in `charts/tee-sniper-api`
 
 ## Docker Migration Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,20 @@ cd api && .venv/bin/python -m pytest tests/test_booking_routes.py -v
 
 # Run the wanted-slot worker once (needs TSA_* env, see api/app/config.py)
 cd api && .venv/bin/python -m app.cli.worker
+
+# Session integration tests need a real Redis. Without one they SKIP:
+docker run -d -p 6379:6379 redis   # then: cd api && .venv/bin/python -m pytest tests/test_session_integration.py
 ```
+
+**`TSA_REQUIRE_REDIS`**: the session integration tests
+(`tests/test_session_integration.py`) skip silently when Redis is
+unreachable — convenient locally, dangerous in CI (a broken Redis service
+would yield a green build that stopped regression-testing session handling).
+Setting `TSA_REQUIRE_REDIS=1` turns that silent skip into a hard collection
+error. It is set in `.github/workflows/api-build.yml` (which also provisions
+a `redis:8-alpine` service), so CI always runs these tests and fails loudly
+if Redis is missing. Leave it unset locally to keep the skip-when-absent
+convenience.
 
 ### Building
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Plan: `docs/superpowers/plans/2026-05-16-wanted-tee-times.md`.
 - Models: `api/app/models/wanted.py`
 - Store: `api/app/services/wanted_store.py` (Redis `wanted:{id}` + `wanted:index`)
 - Scheduling predicate: `api/app/services/scheduling.py` (`is_due`, 8-day window)
-- Worker: `api/app/services/worker.py` (`run_once`), CLI `app/cli/worker.py`
+- Worker: `api/app/services/worker.py` (`run_once`), CLI `api/app/cli/worker.py`
 - Router: `api/app/routers/wanted.py` (`/api/wanted`)
 - Deploy: opt-in `worker` CronJob in `charts/tee-sniper-api`
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,14 @@ The project includes GitHub Actions workflows:
 - **Build** (`.github/workflows/build.yml`): Runs on push to main and pull requests. Executes build and test steps.
 - **Release** (`.github/workflows/release.yml`): Triggers on version tags (v*.*.*). Builds Linux binary, creates GitHub release, and pushes Docker image to GitHub Container Registry.
 
+## Roadmap
+
+Planned follow-up work (see `docs/superpowers/specs/` for designs):
+
+- [ ] **Wanted tee-times** — persisted booking requests (one-shot by date, or recurring by day-of-week) processed by a daily worker. Design: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+- [ ] **Decommission the Go CLI** — replace `cmd/tee-sniper/`, `pkg/`, `run-teesniper.sh`, and the Go CI with the Python worker once it is proven at parity (separate spec to follow).
+- [ ] **MCP tools for wanted tee-times** — expose create/list/delete of wanted-slots via the MCP server (separate spec to follow).
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ The `api/` directory contains a Python FastAPI service that exposes the booking 
 
 All endpoints except `/health` and `/api/login` require an `Authorization: Bearer <token>` header obtained from the login endpoint.
 
+#### Wanted tee-times
+
+Register a request to auto-book a slot when it becomes available:
+
+- `POST /api/wanted?kind=one_shot|recurring` — create a request
+- `GET /api/wanted[?status=pending|booked|expired|disabled]` — list requests
+- `GET /api/wanted/{id}` — fetch one (incl. attempt history)
+- `PATCH /api/wanted/{id}` — update window/partners/notify or disable
+- `DELETE /api/wanted/{id}` — remove
+
+A daily worker (`python -m app.cli.worker`, deployed as the opt-in
+`worker` Helm CronJob) processes due requests, books a matching slot, records
+the outcome, and optionally sends a Twilio SMS.
+
 ### API Configuration
 
 Environment variables (prefixed with `TSA_`):
@@ -378,7 +392,7 @@ The project includes GitHub Actions workflows:
 
 Planned follow-up work (see `docs/superpowers/specs/` for designs):
 
-- [ ] **Wanted tee-times** — persisted booking requests (one-shot by date, or recurring by day-of-week) processed by a daily worker. Design: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+- [x] **Wanted tee-times** — persisted booking requests (one-shot by date, or recurring by day-of-week) processed by a daily worker. Design: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
 - [ ] **Decommission the Go CLI** — replace `cmd/tee-sniper/`, `pkg/`, `run-teesniper.sh`, and the Go CI with the Python worker once it is proven at parity (separate spec to follow).
 - [ ] **MCP tools for wanted tee-times** — expose create/list/delete of wanted-slots via the MCP server (separate spec to follow).
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Environment variables (prefixed with `TSA_`):
 | `TSA_API_PORT` | API listen port | No | `8000` |
 | `TSA_LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR) | No | `INFO` |
 | `TSA_LOG_FORMAT` | Log format (`json` or `text`) | No | `json` |
+| `TSA_REQUIRE_REDIS` | Test-only. When `1`, the session integration tests fail loudly instead of skipping if Redis is unreachable (set in CI). | No | unset |
 
 ### Running the API
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ Register a request to auto-book a slot when it becomes available:
 
 - `POST /api/wanted?kind=one_shot|recurring` — create a request
 - `GET /api/wanted[?status=pending|booked|expired|disabled]` — list requests
-- `GET /api/wanted/{id}` — fetch one (incl. attempt history)
-- `PATCH /api/wanted/{id}` — update window/partners/notify or disable
-- `DELETE /api/wanted/{id}` — remove
+- `GET /api/wanted/{slot_id}` — fetch one (incl. attempt history)
+- `PATCH /api/wanted/{slot_id}` — update window/partners/notify or disable
+- `DELETE /api/wanted/{slot_id}` — remove
 
 A daily worker (`python -m app.cli.worker`, deployed as the opt-in
 `worker` Helm CronJob) processes due requests, books a matching slot, records

--- a/api/app/cli/__init__.py
+++ b/api/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entrypoints for tee-sniper-api."""

--- a/api/app/cli/worker.py
+++ b/api/app/cli/worker.py
@@ -17,6 +17,27 @@ from app.services.worker import run_once
 logger = logging.getLogger(__name__)
 
 
+def _configure_logging() -> None:
+    """Mirror app.main.setup_logging for the standalone worker (no app import)."""
+    from pythonjsonlogger import jsonlogger
+
+    settings = get_settings()
+    handler = logging.StreamHandler(sys.stdout)
+    if settings.log_format == "json":
+        formatter = jsonlogger.JsonFormatter(
+            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            rename_fields={"asctime": "time", "levelname": "level"},
+        )
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(settings.log_level)
+
+
 async def _run() -> None:
     settings = get_settings()
     redis = make_redis_client()
@@ -34,7 +55,7 @@ async def _run() -> None:
 
 
 def main() -> None:
-    logging.basicConfig(level=get_settings().log_level)
+    _configure_logging()
     try:
         asyncio.run(_run())
     except Exception:  # noqa: BLE001

--- a/api/app/cli/worker.py
+++ b/api/app/cli/worker.py
@@ -1,0 +1,46 @@
+"""`python -m app.cli.worker` — run one wanted-slot booking pass."""
+
+import asyncio
+import logging
+import sys
+
+from app.config import get_settings
+from app.dependencies import (
+    get_encryption_service,
+    make_redis_client,
+    make_sms_notifier,
+    make_wanted_store,
+)
+from app.services.booking_client import BookingClient
+from app.services.worker import run_once
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    settings = get_settings()
+    redis = make_redis_client()
+    try:
+        store = make_wanted_store(redis)
+        await run_once(
+            store,
+            client_factory=lambda base_url, **_: BookingClient(base_url=base_url),
+            encryption=get_encryption_service(),
+            notifier=make_sms_notifier(),
+            base_url=settings.base_url,
+        )
+    finally:
+        await redis.aclose()
+
+
+def main() -> None:
+    logging.basicConfig(level=get_settings().log_level)
+    try:
+        asyncio.run(_run())
+    except Exception:  # noqa: BLE001
+        logger.exception("Worker run failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     # Format: {"id1": "Alice Smith", "id2": "Bob Jones"}
     partners_file: str | None = None
 
+    # Twilio SMS (optional; required only when the worker sends notifications)
+    twilio_account_sid: str | None = None
+    twilio_auth_token: str | None = None
+    twilio_from_number: str | None = None
+
     # Logging
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     log_format: Literal["json", "text"] = "json"

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -36,7 +36,7 @@ def get_partners_service() -> "PartnersService":
     return PartnersService(settings.partners_file)
 
 
-def make_redis_client():
+def make_redis_client() -> Redis:
     """Construct a standalone Redis client (no pooling) for CLI use."""
     from redis.asyncio import Redis as _Redis
 
@@ -44,14 +44,14 @@ def make_redis_client():
     return _Redis.from_url(settings.redis_url, decode_responses=True)
 
 
-def make_wanted_store(redis):
+def make_wanted_store(redis: Redis) -> "WantedStore":
     """Construct a WantedStore for the given Redis client."""
     from app.services.wanted_store import WantedStore
 
     return WantedStore(redis)
 
 
-def make_sms_notifier():
+def make_sms_notifier() -> "SmsNotifier":
     """Construct an SmsNotifier from settings."""
     from app.services.notifications import SmsNotifier
 

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -36,6 +36,33 @@ def get_partners_service() -> "PartnersService":
     return PartnersService(settings.partners_file)
 
 
+def make_redis_client():
+    """Construct a standalone Redis client (no pooling) for CLI use."""
+    from redis.asyncio import Redis as _Redis
+
+    settings = get_settings()
+    return _Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def make_wanted_store(redis):
+    """Construct a WantedStore for the given Redis client."""
+    from app.services.wanted_store import WantedStore
+
+    return WantedStore(redis)
+
+
+def make_sms_notifier():
+    """Construct an SmsNotifier from settings."""
+    from app.services.notifications import SmsNotifier
+
+    settings = get_settings()
+    return SmsNotifier(
+        account_sid=settings.twilio_account_sid,
+        auth_token=settings.twilio_auth_token,
+        default_from=settings.twilio_from_number,
+    )
+
+
 def get_settings_dependency() -> Settings:
     """Dependency for injecting settings into routes."""
     return get_settings()

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -97,6 +97,15 @@ async def get_redis() -> Redis:
     return Redis(connection_pool=pool)
 
 
+async def get_wanted_store(
+    redis: Redis = Depends(get_redis),
+) -> "WantedStore":
+    """Request-scoped WantedStore for the API router."""
+    from app.services.wanted_store import WantedStore
+
+    return WantedStore(redis)
+
+
 async def close_redis_pool() -> None:
     """Close Redis connection pool (for application shutdown)."""
     global _redis_pool

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,7 +12,7 @@ from pythonjsonlogger import jsonlogger
 from app.config import get_settings
 from app.dependencies import close_redis_pool, get_redis
 from app.models.responses import HealthResponse
-from app.routers import booking_router
+from app.routers import booking_router, wanted_router
 
 
 def setup_logging() -> None:
@@ -93,6 +93,7 @@ def create_app() -> FastAPI:
 
     # Register routers
     app.include_router(booking_router)
+    app.include_router(wanted_router)
 
     # Health check endpoint
     @app.get(

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -10,6 +10,18 @@ from app.models.responses import (
     LoginResponse,
     TimeSlotResponse,
 )
+from app.models.wanted import (
+    Attempt,
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    Notify,
+    Outcome,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
 
 __all__ = [
     "TimeSlot",
@@ -22,4 +34,14 @@ __all__ = [
     "BookResponse",
     "AddPartnersResponse",
     "HealthResponse",
+    "Attempt",
+    "CreateOneShotRequest",
+    "CreateRecurringRequest",
+    "Notify",
+    "Outcome",
+    "PatchWantedRequest",
+    "WantedKind",
+    "WantedResponse",
+    "WantedSlot",
+    "WantedStatus",
 ]

--- a/api/app/models/wanted.py
+++ b/api/app/models/wanted.py
@@ -89,7 +89,7 @@ class _CreateBase(BaseModel):
     notify: Notify | None = None
 
     @model_validator(mode="after")
-    def _window(self):
+    def _window(self) -> "_CreateBase":
         if self.end_time <= self.start_time:
             raise ValueError("end_time must be after start_time")
         return self
@@ -112,6 +112,13 @@ class PatchWantedRequest(BaseModel):
     notify: Notify | None = None
     disabled: bool | None = None
     credentials: str | None = None
+
+    @model_validator(mode="after")
+    def _window(self) -> "PatchWantedRequest":
+        if self.start_time is not None and self.end_time is not None:
+            if self.end_time <= self.start_time:
+                raise ValueError("end_time must be after start_time")
+        return self
 
 
 class WantedResponse(BaseModel):
@@ -136,4 +143,4 @@ class WantedResponse(BaseModel):
         data = slot.model_dump()
         data.pop("credentials")
         data["has_credentials"] = bool(slot.credentials)
-        return cls(**data)
+        return cls.model_validate(data)

--- a/api/app/models/wanted.py
+++ b/api/app/models/wanted.py
@@ -1,0 +1,139 @@
+"""Pydantic models for wanted tee-time requests."""
+
+from __future__ import annotations
+
+import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class WantedKind(str, Enum):
+    ONE_SHOT = "one_shot"
+    RECURRING = "recurring"
+
+
+class WantedStatus(str, Enum):
+    PENDING = "pending"
+    BOOKED = "booked"
+    EXPIRED = "expired"
+    DISABLED = "disabled"
+
+
+class Outcome(str, Enum):
+    BOOKED = "booked"
+    NO_SLOTS = "no_slots"
+    AUTH_FAILED = "auth_failed"
+    UPSTREAM_ERROR = "upstream_error"
+    BOOKING_FAILED = "booking_failed"
+
+
+class Notify(BaseModel):
+    to: str = Field(..., description="Destination phone number, E.164")
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description="Sender number; falls back to server default when unset",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class Attempt(BaseModel):
+    ts: datetime.datetime
+    target_date: datetime.date
+    outcome: Outcome
+    booking_id: str | None = None
+    error: str | None = None
+
+
+_HHMM = r"^\d{2}:\d{2}$"
+
+
+class WantedSlot(BaseModel):
+    """Storage model persisted in Redis."""
+
+    id: str
+    kind: WantedKind
+    target_date: datetime.date | None = None
+    day_of_week: int | None = Field(default=None, ge=0, le=6)
+    end_date: datetime.date | None = None
+    start_time: str = Field(..., pattern=_HHMM)
+    end_time: str = Field(..., pattern=_HHMM)
+    num_slots: int = Field(..., ge=1, le=4)
+    partners: list[str] = Field(default_factory=list, max_length=3)
+    credentials: str
+    notify: Notify | None = None
+    status: WantedStatus = WantedStatus.PENDING
+    attempts: list[Attempt] = Field(default_factory=list)
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @model_validator(mode="after")
+    def _check_kind_fields(self) -> "WantedSlot":
+        if self.kind is WantedKind.ONE_SHOT and self.target_date is None:
+            raise ValueError("one_shot requires target_date")
+        if self.kind is WantedKind.RECURRING and self.day_of_week is None:
+            raise ValueError("recurring requires day_of_week")
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be after start_time")
+        return self
+
+
+class _CreateBase(BaseModel):
+    start_time: str = Field(..., pattern=_HHMM)
+    end_time: str = Field(..., pattern=_HHMM)
+    num_slots: int = Field(default=1, ge=1, le=4)
+    partners: list[str] = Field(default_factory=list, max_length=3)
+    credentials: str
+    notify: Notify | None = None
+
+    @model_validator(mode="after")
+    def _window(self):
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be after start_time")
+        return self
+
+
+class CreateOneShotRequest(_CreateBase):
+    target_date: datetime.date
+
+
+class CreateRecurringRequest(_CreateBase):
+    day_of_week: int = Field(..., ge=0, le=6)
+    end_date: datetime.date | None = None
+
+
+class PatchWantedRequest(BaseModel):
+    start_time: str | None = Field(default=None, pattern=_HHMM)
+    end_time: str | None = Field(default=None, pattern=_HHMM)
+    num_slots: int | None = Field(default=None, ge=1, le=4)
+    partners: list[str] | None = Field(default=None, max_length=3)
+    notify: Notify | None = None
+    disabled: bool | None = None
+    credentials: str | None = None
+
+
+class WantedResponse(BaseModel):
+    id: str
+    kind: WantedKind
+    target_date: datetime.date | None
+    day_of_week: int | None
+    end_date: datetime.date | None
+    start_time: str
+    end_time: str
+    num_slots: int
+    partners: list[str]
+    has_credentials: bool
+    notify: Notify | None
+    status: WantedStatus
+    attempts: list[Attempt]
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @classmethod
+    def from_slot(cls, slot: WantedSlot) -> "WantedResponse":
+        data = slot.model_dump()
+        data.pop("credentials")
+        data["has_credentials"] = bool(slot.credentials)
+        return cls(**data)

--- a/api/app/models/wanted.py
+++ b/api/app/models/wanted.py
@@ -105,6 +105,10 @@ class CreateRecurringRequest(_CreateBase):
 
 
 class PatchWantedRequest(BaseModel):
+    # Reject unknown keys (incl. the immutable kind/target_date/day_of_week)
+    # with a 422 instead of silently ignoring them.
+    model_config = {"extra": "forbid"}
+
     start_time: str | None = Field(default=None, pattern=_HHMM)
     end_time: str | None = Field(default=None, pattern=_HHMM)
     num_slots: int | None = Field(default=None, ge=1, le=4)

--- a/api/app/routers/__init__.py
+++ b/api/app/routers/__init__.py
@@ -1,5 +1,6 @@
 """API route handlers."""
 
 from app.routers.booking import router as booking_router
+from app.routers.wanted import router as wanted_router
 
-__all__ = ["booking_router"]
+__all__ = ["booking_router", "wanted_router"]

--- a/api/app/routers/wanted.py
+++ b/api/app/routers/wanted.py
@@ -53,9 +53,11 @@ async def create_wanted(
             extra = dict(kind=kind, day_of_week=req.day_of_week,
                          end_date=req.end_date)
     except ValidationError as exc:
+        # ErrorResponse.detail is a str (consistent with the other routers and
+        # the PATCH path); stringify rather than leak a list of error dicts.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=exc.errors(),
+            detail=str(exc),
         ) from exc
 
     now = _now()

--- a/api/app/routers/wanted.py
+++ b/api/app/routers/wanted.py
@@ -1,0 +1,130 @@
+"""CRUD endpoints for wanted tee-time requests."""
+
+import datetime
+import logging
+import uuid
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
+
+from app.dependencies import get_current_session, get_wanted_store
+from app.models.wanted import (
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.wanted_store import WantedStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/wanted", tags=["Wanted"])
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+@router.post("", response_model=WantedResponse,
+             status_code=status.HTTP_201_CREATED)
+async def create_wanted(
+    kind: WantedKind = Query(...),
+    body: dict = Body(default=None),
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    if kind is WantedKind.ONE_SHOT:
+        req = CreateOneShotRequest.model_validate(body or {})
+        extra = dict(kind=kind, target_date=req.target_date)
+    else:
+        req = CreateRecurringRequest.model_validate(body or {})
+        extra = dict(kind=kind, day_of_week=req.day_of_week,
+                     end_date=req.end_date)
+
+    now = _now()
+    slot = WantedSlot(
+        id=str(uuid.uuid4()),
+        start_time=req.start_time,
+        end_time=req.end_time,
+        num_slots=req.num_slots,
+        partners=req.partners,
+        credentials=req.credentials,
+        notify=req.notify,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=now,
+        updated_at=now,
+        **extra,
+    )
+    await store.create(slot)
+    return WantedResponse.from_slot(slot)
+
+
+@router.get("", response_model=list[WantedResponse])
+async def list_wanted(
+    status_filter: WantedStatus | None = Query(default=None, alias="status"),
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> list[WantedResponse]:
+    slots = await store.list_all()
+    if status_filter is not None:
+        slots = [s for s in slots if s.status is status_filter]
+    return [WantedResponse.from_slot(s) for s in slots]
+
+
+async def _require(store: WantedStore, slot_id: str) -> WantedSlot:
+    slot = await store.get(slot_id)
+    if slot is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Wanted slot not found")
+    return slot
+
+
+@router.get("/{slot_id}", response_model=WantedResponse)
+async def get_wanted(
+    slot_id: str,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    return WantedResponse.from_slot(await _require(store, slot_id))
+
+
+@router.patch("/{slot_id}", response_model=WantedResponse)
+async def patch_wanted(
+    slot_id: str,
+    patch: PatchWantedRequest,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    slot = await _require(store, slot_id)
+    fields = patch.model_dump(exclude_unset=True)
+
+    disabled = fields.pop("disabled", None)
+    for key, value in fields.items():
+        setattr(slot, key, value)
+
+    if disabled is True:
+        slot.status = WantedStatus.DISABLED
+    elif disabled is False and slot.status is WantedStatus.DISABLED:
+        slot.status = WantedStatus.PENDING
+
+    slot.updated_at = _now()
+    # Re-validate window/kind invariants by reconstructing.
+    slot = WantedSlot.model_validate(slot.model_dump())
+    await store.update(slot)
+    return WantedResponse.from_slot(slot)
+
+
+@router.delete("/{slot_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_wanted(
+    slot_id: str,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> Response:
+    deleted = await store.delete(slot_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Wanted slot not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/routers/wanted.py
+++ b/api/app/routers/wanted.py
@@ -5,8 +5,10 @@ import logging
 import uuid
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
+from pydantic import ValidationError
 
 from app.dependencies import get_current_session, get_wanted_store
+from app.models.responses import ErrorResponse
 from app.models.wanted import (
     CreateOneShotRequest,
     CreateRecurringRequest,
@@ -27,21 +29,34 @@ def _now() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-@router.post("", response_model=WantedResponse,
-             status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=WantedResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or expired session"},
+        422: {"model": ErrorResponse, "description": "Invalid request body"},
+    },
+)
 async def create_wanted(
     kind: WantedKind = Query(...),
     body: dict = Body(default=None),
     _session: dict = Depends(get_current_session),
     store: WantedStore = Depends(get_wanted_store),
 ) -> WantedResponse:
-    if kind is WantedKind.ONE_SHOT:
-        req = CreateOneShotRequest.model_validate(body or {})
-        extra = dict(kind=kind, target_date=req.target_date)
-    else:
-        req = CreateRecurringRequest.model_validate(body or {})
-        extra = dict(kind=kind, day_of_week=req.day_of_week,
-                     end_date=req.end_date)
+    try:
+        if kind is WantedKind.ONE_SHOT:
+            req = CreateOneShotRequest.model_validate(body or {})
+            extra = dict(kind=kind, target_date=req.target_date)
+        else:
+            req = CreateRecurringRequest.model_validate(body or {})
+            extra = dict(kind=kind, day_of_week=req.day_of_week,
+                         end_date=req.end_date)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.errors(),
+        ) from exc
 
     now = _now()
     slot = WantedSlot(
@@ -62,7 +77,13 @@ async def create_wanted(
     return WantedResponse.from_slot(slot)
 
 
-@router.get("", response_model=list[WantedResponse])
+@router.get(
+    "",
+    response_model=list[WantedResponse],
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or expired session"},
+    },
+)
 async def list_wanted(
     status_filter: WantedStatus | None = Query(default=None, alias="status"),
     _session: dict = Depends(get_current_session),
@@ -82,7 +103,14 @@ async def _require(store: WantedStore, slot_id: str) -> WantedSlot:
     return slot
 
 
-@router.get("/{slot_id}", response_model=WantedResponse)
+@router.get(
+    "/{slot_id}",
+    response_model=WantedResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or expired session"},
+        404: {"model": ErrorResponse, "description": "Wanted slot not found"},
+    },
+)
 async def get_wanted(
     slot_id: str,
     _session: dict = Depends(get_current_session),
@@ -91,7 +119,15 @@ async def get_wanted(
     return WantedResponse.from_slot(await _require(store, slot_id))
 
 
-@router.patch("/{slot_id}", response_model=WantedResponse)
+@router.patch(
+    "/{slot_id}",
+    response_model=WantedResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or expired session"},
+        404: {"model": ErrorResponse, "description": "Wanted slot not found"},
+        422: {"model": ErrorResponse, "description": "Invalid patch"},
+    },
+)
 async def patch_wanted(
     slot_id: str,
     patch: PatchWantedRequest,
@@ -112,12 +148,27 @@ async def patch_wanted(
 
     slot.updated_at = _now()
     # Re-validate window/kind invariants by reconstructing.
-    slot = WantedSlot.model_validate(slot.model_dump())
+    try:
+        slot = WantedSlot.model_validate(slot.model_dump())
+    except ValidationError as exc:
+        # Use str(exc) — exc.errors() may contain non-serializable objects
+        # (e.g. ValueError in ctx) when pydantic value validators fire.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     await store.update(slot)
     return WantedResponse.from_slot(slot)
 
 
-@router.delete("/{slot_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{slot_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid or expired session"},
+        404: {"model": ErrorResponse, "description": "Wanted slot not found"},
+    },
+)
 async def delete_wanted(
     slot_id: str,
     _session: dict = Depends(get_current_session),

--- a/api/app/services/notifications.py
+++ b/api/app/services/notifications.py
@@ -1,0 +1,47 @@
+"""Optional Twilio SMS notifications for the wanted-slot worker."""
+
+import logging
+
+from app.models.wanted import Notify
+
+logger = logging.getLogger(__name__)
+
+
+class SmsNotifier:
+    """Sends SMS via Twilio. A no-op when credentials are not configured.
+
+    Send failures are logged and swallowed: a notification problem must
+    never abort or fail a booking attempt.
+    """
+
+    def __init__(
+        self,
+        account_sid: str | None,
+        auth_token: str | None,
+        default_from: str | None,
+    ):
+        self._account_sid = account_sid
+        self._auth_token = auth_token
+        self._default_from = default_from
+        self._client = None
+        self.enabled = bool(account_sid and auth_token)
+
+    def _ensure_client(self):
+        if self._client is None:
+            from twilio.rest import Client
+
+            self._client = Client(self._account_sid, self._auth_token)
+        return self._client
+
+    def send(self, notify: Notify | None, body: str) -> None:
+        if notify is None or not self.enabled:
+            return
+        sender = notify.from_ or self._default_from
+        if not sender:
+            logger.warning("No 'from' number available; skipping SMS")
+            return
+        try:
+            client = self._ensure_client()
+            client.messages.create(to=notify.to, from_=sender, body=body)
+        except Exception as exc:  # noqa: BLE001 - never propagate
+            logger.warning("Failed to send SMS", extra={"error": str(exc)})

--- a/api/app/services/notifications.py
+++ b/api/app/services/notifications.py
@@ -1,8 +1,14 @@
 """Optional Twilio SMS notifications for the wanted-slot worker."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from app.models.wanted import Notify
+
+if TYPE_CHECKING:
+    from twilio.rest import Client
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +32,7 @@ class SmsNotifier:
         self._client = None
         self.enabled = bool(account_sid and auth_token)
 
-    def _ensure_client(self):
+    def _ensure_client(self) -> "Client":
         if self._client is None:
             from twilio.rest import Client
 

--- a/api/app/services/scheduling.py
+++ b/api/app/services/scheduling.py
@@ -1,0 +1,45 @@
+"""Pure scheduling predicate: is a wanted slot due on a given day?"""
+
+import datetime
+
+from app.models.wanted import Outcome, WantedKind, WantedSlot, WantedStatus
+
+RELEASE_WINDOW_DAYS = 8
+
+
+def target_for(slot: WantedSlot, today: datetime.date) -> datetime.date | None:
+    """The play date this slot would attempt to book if run today."""
+    if slot.kind is WantedKind.ONE_SHOT:
+        return slot.target_date
+    release = today + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+    if release.weekday() != slot.day_of_week:
+        return None
+    return release
+
+
+def is_due(slot: WantedSlot, today: datetime.date) -> bool:
+    """True if the worker should attempt this slot today."""
+    if slot.status in (
+        WantedStatus.BOOKED,
+        WantedStatus.EXPIRED,
+        WantedStatus.DISABLED,
+    ):
+        return False
+
+    release = today + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+
+    if slot.kind is WantedKind.ONE_SHOT:
+        td = slot.target_date
+        return td is not None and today <= td <= release
+
+    # Recurring
+    target = target_for(slot, today)
+    if target is None:
+        return False
+    if slot.end_date is not None and target > slot.end_date:
+        return False
+    already_booked = any(
+        a.outcome is Outcome.BOOKED and a.target_date == target
+        for a in slot.attempts
+    )
+    return not already_booked

--- a/api/app/services/wanted_store.py
+++ b/api/app/services/wanted_store.py
@@ -1,0 +1,69 @@
+"""Redis persistence for wanted tee-time requests."""
+
+import datetime
+import logging
+
+from redis.asyncio import Redis
+
+from app.models.wanted import WantedKind, WantedSlot
+
+logger = logging.getLogger(__name__)
+
+
+class WantedStore:
+    """CRUD for WantedSlot records, with a set index for enumeration."""
+
+    KEY_PREFIX = "wanted:"
+    INDEX_KEY = "wanted:index"
+    ONE_SHOT_GRACE_DAYS = 30
+
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    def _key(self, slot_id: str) -> str:
+        return f"{self.KEY_PREFIX}{slot_id}"
+
+    def _ttl_seconds(self, slot: WantedSlot) -> int | None:
+        if slot.kind is not WantedKind.ONE_SHOT or slot.target_date is None:
+            return None
+        expiry = slot.target_date + datetime.timedelta(days=self.ONE_SHOT_GRACE_DAYS)
+        delta = expiry - datetime.date.today()
+        return max(int(delta.total_seconds()), 60)
+
+    async def create(self, slot: WantedSlot) -> None:
+        await self._write(slot)
+        await self.redis.sadd(self.INDEX_KEY, slot.id)
+        logger.info("Wanted slot created", extra={"id": slot.id, "kind": slot.kind.value})
+
+    async def update(self, slot: WantedSlot) -> None:
+        await self._write(slot)
+
+    async def _write(self, slot: WantedSlot) -> None:
+        ttl = self._ttl_seconds(slot)
+        payload = slot.model_dump_json()
+        if ttl is not None:
+            await self.redis.set(self._key(slot.id), payload, ex=ttl)
+        else:
+            await self.redis.set(self._key(slot.id), payload)
+
+    async def get(self, slot_id: str) -> WantedSlot | None:
+        raw = await self.redis.get(self._key(slot_id))
+        if raw is None:
+            return None
+        return WantedSlot.model_validate_json(raw)
+
+    async def list_all(self) -> list[WantedSlot]:
+        ids = await self.redis.smembers(self.INDEX_KEY)
+        result: list[WantedSlot] = []
+        for slot_id in ids:
+            slot = await self.get(slot_id)
+            if slot is None:
+                await self.redis.srem(self.INDEX_KEY, slot_id)  # prune expired
+                continue
+            result.append(slot)
+        return result
+
+    async def delete(self, slot_id: str) -> bool:
+        removed = await self.redis.delete(self._key(slot_id))
+        await self.redis.srem(self.INDEX_KEY, slot_id)
+        return removed > 0

--- a/api/app/services/wanted_store.py
+++ b/api/app/services/wanted_store.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 class WantedStore:
     """CRUD for WantedSlot records, with a set index for enumeration."""
 
+    # Slot IDs are UUIDs (assigned by the router); an id of "index" would
+    # collide with INDEX_KEY. UUIDs make that impossible in practice.
     KEY_PREFIX = "wanted:"
     INDEX_KEY = "wanted:index"
     ONE_SHOT_GRACE_DAYS = 30
@@ -23,11 +25,12 @@ class WantedStore:
     def _key(self, slot_id: str) -> str:
         return f"{self.KEY_PREFIX}{slot_id}"
 
-    def _ttl_seconds(self, slot: WantedSlot) -> int | None:
+    def _ttl_seconds(self, slot: WantedSlot, today: datetime.date | None = None) -> int | None:
         if slot.kind is not WantedKind.ONE_SHOT or slot.target_date is None:
             return None
+        today = today or datetime.date.today()
         expiry = slot.target_date + datetime.timedelta(days=self.ONE_SHOT_GRACE_DAYS)
-        delta = expiry - datetime.date.today()
+        delta = expiry - today
         return max(int(delta.total_seconds()), 60)
 
     async def create(self, slot: WantedSlot) -> None:
@@ -37,6 +40,7 @@ class WantedStore:
 
     async def update(self, slot: WantedSlot) -> None:
         await self._write(slot)
+        await self.redis.sadd(self.INDEX_KEY, slot.id)
 
     async def _write(self, slot: WantedSlot) -> None:
         ttl = self._ttl_seconds(slot)
@@ -58,7 +62,7 @@ class WantedStore:
         for slot_id in ids:
             slot = await self.get(slot_id)
             if slot is None:
-                await self.redis.srem(self.INDEX_KEY, slot_id)  # prune expired
+                await self.redis.srem(self.INDEX_KEY, slot_id)  # record expired in Redis but the index entry survived; drop it
                 continue
             result.append(slot)
         return result

--- a/api/app/services/worker.py
+++ b/api/app/services/worker.py
@@ -137,7 +137,14 @@ async def run_once(
         if att.outcome is Outcome.BOOKED and slot.kind is WantedKind.ONE_SHOT:
             slot.status = WantedStatus.BOOKED
 
-        await store.update(slot)
+        try:
+            await store.update(slot)
+        except Exception as exc:  # noqa: BLE001 - one record must not abort the run
+            logger.error(
+                "Failed to persist slot after attempt; skipping notify",
+                extra={"id": slot.id, "error": str(exc)},
+            )
+            continue
 
         if slot.notify is not None:
             if att.outcome is Outcome.BOOKED:

--- a/api/app/services/worker.py
+++ b/api/app/services/worker.py
@@ -1,0 +1,155 @@
+"""Daily worker: scan wanted slots, attempt due ones, record outcomes."""
+
+import datetime
+import logging
+import random
+from collections.abc import Callable
+
+from app.models.wanted import (
+    Attempt,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.booking_client import (
+    BookingClient,
+    BookingClientError,
+    BookingError,
+    LoginError,
+)
+from app.services.scheduling import is_due, target_for
+from app.services.wanted_store import WantedStore
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS_KEPT = 10
+
+ClientFactory = Callable[..., BookingClient]
+
+
+def _record(slot: WantedSlot, target: datetime.date, outcome: Outcome,
+            booking_id: str | None = None, error: str | None = None) -> Attempt:
+    att = Attempt(
+        ts=datetime.datetime.now(datetime.timezone.utc),
+        target_date=target,
+        outcome=outcome,
+        booking_id=booking_id,
+        error=error,
+    )
+    slot.attempts.append(att)
+    del slot.attempts[:-MAX_ATTEMPTS_KEPT]
+    slot.updated_at = att.ts
+    return att
+
+
+async def _attempt(slot: WantedSlot, target: datetime.date, *,
+                   client_factory: ClientFactory, encryption, base_url: str) -> Attempt:
+    try:
+        username, pin = encryption.decrypt_credentials(slot.credentials)
+    except Exception as exc:  # noqa: BLE001
+        return _record(slot, target, Outcome.AUTH_FAILED, error=str(exc))
+
+    client = client_factory(base_url=base_url)
+    try:
+        async with client:
+            try:
+                await client.login(username, pin)
+            except LoginError as exc:
+                return _record(slot, target, Outcome.AUTH_FAILED, error=str(exc))
+
+            client_date = target.strftime("%d-%m-%Y")
+            try:
+                slots = await client.get_availability(client_date)
+            except BookingClientError as exc:
+                return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+            candidates = [
+                s for s in slots
+                if s.can_book and slot.start_time <= s.time <= slot.end_time
+            ]
+            if not candidates:
+                return _record(slot, target, Outcome.NO_SLOTS)
+
+            chosen = random.choice(candidates)
+            try:
+                booking_id = await client.book_time_slot(chosen, slot.num_slots)
+            except BookingError as exc:
+                return _record(slot, target, Outcome.BOOKING_FAILED, error=str(exc))
+            except BookingClientError as exc:
+                return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+            for i, partner_id in enumerate(slot.partners):
+                try:
+                    await client.add_partner(booking_id, partner_id, i + 2)
+                except (BookingClientError, BookingError) as exc:
+                    logger.warning(
+                        "Failed to add partner",
+                        extra={"id": slot.id, "partner": partner_id,
+                               "error": str(exc)},
+                    )
+
+            return _record(slot, target, Outcome.BOOKED, booking_id=booking_id)
+    except Exception as exc:  # noqa: BLE001 - one record must not abort the run
+        return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+
+async def run_once(
+    store: WantedStore,
+    *,
+    client_factory: ClientFactory,
+    encryption,
+    notifier,
+    base_url: str,
+    today: datetime.date | None = None,
+) -> None:
+    today = today or datetime.date.today()
+    slots = await store.list_all()
+    logger.info("Worker run starting", extra={"count": len(slots), "today": str(today)})
+
+    for slot in slots:
+        # Expire stale one-shots without an attempt.
+        if (
+            slot.kind is WantedKind.ONE_SHOT
+            and slot.status is WantedStatus.PENDING
+            and slot.target_date is not None
+            and slot.target_date < today
+        ):
+            slot.status = WantedStatus.EXPIRED
+            slot.updated_at = datetime.datetime.now(datetime.timezone.utc)
+            await store.update(slot)
+            continue
+
+        if not is_due(slot, today):
+            continue
+
+        target = target_for(slot, today)
+        if target is None:
+            continue
+
+        att = await _attempt(
+            slot, target,
+            client_factory=client_factory,
+            encryption=encryption,
+            base_url=base_url,
+        )
+
+        if att.outcome is Outcome.BOOKED and slot.kind is WantedKind.ONE_SHOT:
+            slot.status = WantedStatus.BOOKED
+
+        await store.update(slot)
+
+        if slot.notify is not None:
+            if att.outcome is Outcome.BOOKED:
+                body = (
+                    f"Booked tee time for {target.isoformat()} "
+                    f"({slot.num_slots} slot(s)). Booking {att.booking_id}."
+                )
+            else:
+                body = (
+                    f"Tee-time attempt for {target.isoformat()} "
+                    f"failed: {att.outcome.value}."
+                )
+            notifier.send(slot.notify, body)
+
+    logger.info("Worker run finished")

--- a/api/app/services/worker.py
+++ b/api/app/services/worker.py
@@ -117,7 +117,13 @@ async def run_once(
         ):
             slot.status = WantedStatus.EXPIRED
             slot.updated_at = datetime.datetime.now(datetime.timezone.utc)
-            await store.update(slot)
+            try:
+                await store.update(slot)
+            except Exception as exc:  # noqa: BLE001 - one record must not abort the run
+                logger.error(
+                    "Failed to persist expired one-shot; continuing",
+                    extra={"id": slot.id, "error": str(exc)},
+                )
             continue
 
         if not is_due(slot, today):

--- a/api/encrypt_credentials.py
+++ b/api/encrypt_credentials.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Encrypt booking-site credentials into the blob the API expects.
+
+The /api/login and /api/wanted endpoints never take a plaintext PIN — they
+take an AES-256-GCM blob produced with the same TSA_SHARED_SECRET the API
+runs with. This script produces that blob.
+
+Resolution order for the shared secret:
+  1. --secret PINVALUE
+  2. $TSA_SHARED_SECRET
+  3. TSA_SHARED_SECRET=... in ./.env or ../.env (repo-root .env)
+
+Usage (from repo root or from api/):
+  python3 api/encrypt_credentials.py                    # prompts for both
+  python3 api/encrypt_credentials.py -u 12345           # prompts for PIN
+  python3 api/encrypt_credentials.py -u 12345 -p 6789
+  python3 api/encrypt_credentials.py -u 12345 --curl    # also print curl JSON
+
+Tip: piping the PIN avoids it landing in shell history:
+  python3 api/encrypt_credentials.py -u 12345 --pin-stdin <<<'6789'
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import sys
+from pathlib import Path
+
+# Make `app` importable whether run from repo root or from api/.
+_API_DIR = Path(__file__).resolve().parent
+if str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+
+def _secret_from_dotenv() -> str | None:
+    """Look for TSA_SHARED_SECRET in ./.env then ../.env."""
+    for env_path in (_API_DIR / ".env", _API_DIR.parent / ".env"):
+        if not env_path.is_file():
+            continue
+        for raw in env_path.read_text().splitlines():
+            line = raw.strip()
+            if line.startswith("TSA_SHARED_SECRET="):
+                return line.split("=", 1)[1].strip().strip("'\"")
+    return None
+
+
+def resolve_secret(cli_secret: str | None) -> str:
+    secret = cli_secret or os.environ.get("TSA_SHARED_SECRET") or _secret_from_dotenv()
+    if not secret:
+        sys.exit(
+            "error: shared secret not found. Pass --secret, set "
+            "TSA_SHARED_SECRET, or add it to .env (repo root)."
+        )
+    return secret
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Encrypt member ID + PIN into the API credentials blob."
+    )
+    parser.add_argument("-u", "--member-id", help="Booking-site member ID")
+    parser.add_argument("-p", "--pin", help="Booking-site PIN (omit to be prompted)")
+    parser.add_argument(
+        "--pin-stdin",
+        action="store_true",
+        help="Read the PIN from stdin instead of prompting",
+    )
+    parser.add_argument(
+        "--secret",
+        help="TSA_SHARED_SECRET (else env, else .env)",
+    )
+    parser.add_argument(
+        "--curl",
+        action="store_true",
+        help="Also print a ready-to-use JSON body for /api/login",
+    )
+    args = parser.parse_args()
+
+    secret = resolve_secret(args.secret)
+
+    member_id = args.member_id or input("Member ID: ").strip()
+    if not member_id:
+        sys.exit("error: member ID is required")
+
+    if args.pin:
+        pin = args.pin
+    elif args.pin_stdin:
+        pin = sys.stdin.readline().rstrip("\n")
+    else:
+        pin = getpass.getpass("PIN: ")
+    if not pin:
+        sys.exit("error: PIN is required")
+
+    try:
+        from app.services.encryption import EncryptionService
+    except ModuleNotFoundError as exc:  # pragma: no cover - env guidance
+        sys.exit(
+            f"error: could not import the app ({exc}). Run with the API "
+            "virtualenv, e.g. `api/.venv/bin/python api/encrypt_credentials.py`."
+        )
+
+    blob = EncryptionService(secret).encrypt_credentials(member_id, pin)
+    print(blob)
+
+    if args.curl:
+        print()
+        print("# POST body for /api/login (and the credentials field for /api/wanted):")
+        print(f'{{"credentials": "{blob}"}}')
+
+
+if __name__ == "__main__":
+    main()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -19,6 +19,9 @@ pydantic-settings>=2.1.0
 # Encryption
 cryptography>=42.0.0
 
+# SMS notifications
+twilio>=9.0.0
+
 # Logging
 python-json-logger>=2.0.0
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -27,3 +27,4 @@ pytest>=7.4.0
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
 pytest-httpx>=0.30.0
+fakeredis>=2.21.0

--- a/api/tests/test_cli_worker.py
+++ b/api/tests/test_cli_worker.py
@@ -1,0 +1,26 @@
+"""Tests for the CLI worker entrypoint wiring."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.cli.worker import main
+
+
+def test_main_wires_dependencies_and_invokes_run_once():
+    fake_redis = MagicMock()
+    fake_redis.aclose = AsyncMock()
+    fake_store = MagicMock()
+
+    with patch("app.cli.worker.make_redis_client", return_value=fake_redis), \
+         patch("app.cli.worker.make_wanted_store", return_value=fake_store), \
+         patch("app.cli.worker.make_sms_notifier", return_value=MagicMock()), \
+         patch("app.cli.worker.get_encryption_service", return_value=MagicMock()), \
+         patch("app.cli.worker.get_settings") as gs, \
+         patch("app.cli.worker.run_once", new=AsyncMock()) as run_once_mock:
+        gs.return_value.base_url = "https://golf.example.com"
+        main()
+
+    run_once_mock.assert_awaited_once()
+    _, kwargs = run_once_mock.call_args
+    assert kwargs["base_url"] == "https://golf.example.com"
+    assert "client_factory" in kwargs
+    fake_redis.aclose.assert_awaited_once()

--- a/api/tests/test_cli_worker.py
+++ b/api/tests/test_cli_worker.py
@@ -17,6 +17,8 @@ def test_main_wires_dependencies_and_invokes_run_once():
          patch("app.cli.worker.get_settings") as gs, \
          patch("app.cli.worker.run_once", new=AsyncMock()) as run_once_mock:
         gs.return_value.base_url = "https://golf.example.com"
+        gs.return_value.log_format = "text"
+        gs.return_value.log_level = "INFO"
         main()
 
     run_once_mock.assert_awaited_once()
@@ -25,3 +27,20 @@ def test_main_wires_dependencies_and_invokes_run_once():
     assert kwargs["base_url"] == "https://golf.example.com"
     assert "client_factory" in kwargs
     fake_redis.aclose.assert_awaited_once()
+
+
+def test_configure_logging_uses_json_formatter(monkeypatch):
+    import logging as _logging
+
+    from app.cli import worker as w
+
+    fake_settings = MagicMock()
+    fake_settings.log_format = "json"
+    fake_settings.log_level = "INFO"
+    with patch("app.cli.worker.get_settings", return_value=fake_settings):
+        w._configure_logging()
+    root = _logging.getLogger()
+    assert root.handlers
+    assert root.handlers[0].formatter.__class__.__name__ == "JsonFormatter"
+    # restore sane logging for the rest of the suite
+    _logging.getLogger().handlers = []

--- a/api/tests/test_cli_worker.py
+++ b/api/tests/test_cli_worker.py
@@ -20,7 +20,8 @@ def test_main_wires_dependencies_and_invokes_run_once():
         main()
 
     run_once_mock.assert_awaited_once()
-    _, kwargs = run_once_mock.call_args
+    args, kwargs = run_once_mock.call_args
+    assert args[0] is fake_store
     assert kwargs["base_url"] == "https://golf.example.com"
     assert "client_factory" in kwargs
     fake_redis.aclose.assert_awaited_once()

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -1,0 +1,56 @@
+"""Tests for the Twilio SMS notifier."""
+
+from unittest.mock import MagicMock
+
+from app.models.wanted import Notify
+from app.services.notifications import SmsNotifier
+
+
+def test_notifier_disabled_when_unconfigured_is_noop():
+    notifier = SmsNotifier(account_sid=None, auth_token=None, default_from=None)
+    # Must not raise and must not attempt to construct a client.
+    notifier.send(Notify(to="+15550001111"), "hello")
+    assert notifier.enabled is False
+
+
+def test_notifier_sends_with_explicit_from(monkeypatch):
+    fake_client = MagicMock()
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client  # inject
+    notifier.send(Notify(to="+15550001111", **{"from": "+15558888888"}), "booked!")
+    fake_client.messages.create.assert_called_once_with(
+        to="+15550001111", from_="+15558888888", body="booked!"
+    )
+
+
+def test_notifier_falls_back_to_default_from(monkeypatch):
+    fake_client = MagicMock()
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client
+    notifier.send(Notify(to="+15550001111"), "msg")
+    fake_client.messages.create.assert_called_once_with(
+        to="+15550001111", from_="+15559999999", body="msg"
+    )
+
+
+def test_notifier_swallows_send_errors(caplog):
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = RuntimeError("twilio down")
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client
+    # Must not raise — notification failure never aborts a booking.
+    notifier.send(Notify(to="+15550001111"), "msg")
+    assert "Failed to send SMS" in caplog.text
+
+
+def test_send_noop_when_notify_is_none():
+    notifier = SmsNotifier(account_sid="sid", auth_token="tok", default_from="+1")
+    notifier._client = MagicMock()
+    notifier.send(None, "msg")
+    notifier._client.messages.create.assert_not_called()

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -13,7 +13,7 @@ def test_notifier_disabled_when_unconfigured_is_noop():
     assert notifier.enabled is False
 
 
-def test_notifier_sends_with_explicit_from(monkeypatch):
+def test_notifier_sends_with_explicit_from():
     fake_client = MagicMock()
     notifier = SmsNotifier(
         account_sid="sid", auth_token="tok", default_from="+15559999999"
@@ -25,7 +25,7 @@ def test_notifier_sends_with_explicit_from(monkeypatch):
     )
 
 
-def test_notifier_falls_back_to_default_from(monkeypatch):
+def test_notifier_falls_back_to_default_from():
     fake_client = MagicMock()
     notifier = SmsNotifier(
         account_sid="sid", auth_token="tok", default_from="+15559999999"
@@ -53,4 +53,12 @@ def test_send_noop_when_notify_is_none():
     notifier = SmsNotifier(account_sid="sid", auth_token="tok", default_from="+1")
     notifier._client = MagicMock()
     notifier.send(None, "msg")
+    notifier._client.messages.create.assert_not_called()
+
+
+def test_notifier_warns_when_no_from_number(caplog):
+    notifier = SmsNotifier(account_sid="sid", auth_token="tok", default_from=None)
+    notifier._client = MagicMock()
+    notifier.send(Notify(to="+15550001111"), "msg")
+    assert "No 'from' number" in caplog.text
     notifier._client.messages.create.assert_not_called()

--- a/api/tests/test_scheduling.py
+++ b/api/tests/test_scheduling.py
@@ -4,7 +4,6 @@ import datetime
 
 from app.models.wanted import (
     Attempt,
-    Notify,
     Outcome,
     WantedKind,
     WantedSlot,
@@ -103,3 +102,7 @@ def test_recurring_due_again_for_a_different_occurrence():
 
 def test_recurring_past_end_date_not_due():
     assert is_due(_recurring(end_date=RELEASE - datetime.timedelta(days=1)), TODAY) is False
+
+
+def test_recurring_due_on_end_date():
+    assert is_due(_recurring(end_date=RELEASE), TODAY) is True

--- a/api/tests/test_scheduling.py
+++ b/api/tests/test_scheduling.py
@@ -1,0 +1,105 @@
+"""Tests for the is_due / target_for scheduling predicate."""
+
+import datetime
+
+from app.models.wanted import (
+    Attempt,
+    Notify,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.scheduling import RELEASE_WINDOW_DAYS, is_due, target_for
+
+TODAY = datetime.date(2026, 5, 16)  # a Saturday
+RELEASE = TODAY + datetime.timedelta(days=RELEASE_WINDOW_DAYS)  # 2026-05-24, Sunday
+
+
+def _slot(**over) -> WantedSlot:
+    base = dict(
+        id="x",
+        kind=WantedKind.ONE_SHOT,
+        target_date=RELEASE,
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+def test_one_shot_in_release_window_is_due():
+    assert is_due(_slot(target_date=RELEASE), TODAY) is True
+    assert target_for(_slot(target_date=RELEASE), TODAY) == RELEASE
+
+
+def test_one_shot_inside_8_day_window_is_due():
+    near = TODAY + datetime.timedelta(days=3)
+    assert is_due(_slot(target_date=near), TODAY) is True
+
+
+def test_one_shot_beyond_release_window_not_due():
+    far = RELEASE + datetime.timedelta(days=1)
+    assert is_due(_slot(target_date=far), TODAY) is False
+
+
+def test_one_shot_past_target_not_due():
+    past = TODAY - datetime.timedelta(days=1)
+    assert is_due(_slot(target_date=past), TODAY) is False
+
+
+def test_terminal_or_disabled_never_due():
+    assert is_due(_slot(status=WantedStatus.BOOKED), TODAY) is False
+    assert is_due(_slot(status=WantedStatus.EXPIRED), TODAY) is False
+    assert is_due(_slot(status=WantedStatus.DISABLED), TODAY) is False
+
+
+def _recurring(**over) -> WantedSlot:
+    defaults = dict(
+        kind=WantedKind.RECURRING,
+        target_date=None,
+        day_of_week=RELEASE.weekday(),
+    )
+    defaults.update(over)
+    return _slot(**defaults)
+
+
+def test_recurring_due_when_release_matches_day_of_week():
+    assert is_due(_recurring(), TODAY) is True
+    assert target_for(_recurring(), TODAY) == RELEASE
+
+
+def test_recurring_not_due_when_day_of_week_mismatch():
+    assert is_due(_recurring(day_of_week=(RELEASE.weekday() + 1) % 7), TODAY) is False
+
+
+def test_recurring_not_due_when_occurrence_already_booked():
+    booked = Attempt(
+        ts=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        target_date=RELEASE,
+        outcome=Outcome.BOOKED,
+        booking_id="b1",
+    )
+    assert is_due(_recurring(attempts=[booked]), TODAY) is False
+
+
+def test_recurring_due_again_for_a_different_occurrence():
+    old = Attempt(
+        ts=datetime.datetime(2026, 5, 9, tzinfo=datetime.timezone.utc),
+        target_date=RELEASE - datetime.timedelta(days=7),
+        outcome=Outcome.BOOKED,
+        booking_id="b0",
+    )
+    assert is_due(_recurring(attempts=[old]), TODAY) is True
+
+
+def test_recurring_past_end_date_not_due():
+    assert is_due(_recurring(end_date=RELEASE - datetime.timedelta(days=1)), TODAY) is False

--- a/api/tests/test_session_integration.py
+++ b/api/tests/test_session_integration.py
@@ -5,6 +5,10 @@ is not available. Use docker-compose to start Redis:
 
     docker-compose up -d redis
 
+Set TSA_REQUIRE_REDIS=1 (CI does this in .github/workflows/api-build.yml) to
+make an unreachable Redis a hard collection error instead of a silent skip,
+so session-handling regressions can never go untested in CI.
+
 """
 
 import asyncio

--- a/api/tests/test_session_integration.py
+++ b/api/tests/test_session_integration.py
@@ -35,9 +35,20 @@ def redis_available() -> bool:
         return False
 
 
+# Skip all tests in this module if Redis is not available — but only as a
+# local-dev convenience. When TSA_REQUIRE_REDIS=1 (set by CI), an unreachable
+# Redis is a hard error instead of a silent skip, so a broken Redis service
+# can never quietly stop regression-testing session handling.
+_redis_ok = redis_available()
+if os.environ.get("TSA_REQUIRE_REDIS") == "1" and not _redis_ok:
+    raise RuntimeError(
+        "TSA_REQUIRE_REDIS=1 but Redis is unreachable: session integration "
+        "tests would be silently skipped. Failing loudly instead."
+    )
+
 # Skip all tests in this module if Redis is not available
 pytestmark = pytest.mark.skipif(
-    not redis_available(),
+    not _redis_ok,
     reason="Redis not available for integration tests",
 )
 

--- a/api/tests/test_wanted_models.py
+++ b/api/tests/test_wanted_models.py
@@ -153,3 +153,9 @@ def test_recurring_slot_missing_day_of_week_rejected():
 def test_patch_request_rejects_end_before_start_when_both_provided():
     with pytest.raises(ValidationError):
         PatchWantedRequest(start_time="10:00", end_time="08:00")
+
+
+@pytest.mark.parametrize("field", ["day_of_week", "kind", "target_date", "bogus"])
+def test_patch_request_rejects_immutable_or_unknown_fields(field):
+    with pytest.raises(ValidationError):
+        PatchWantedRequest(**{field: 2})

--- a/api/tests/test_wanted_models.py
+++ b/api/tests/test_wanted_models.py
@@ -112,3 +112,44 @@ def test_attempt_and_outcome_enum_serialize():
         booking_id="bk-1",
     )
     assert att.model_dump()["outcome"] == "booked"
+
+
+def test_one_shot_slot_requires_target_date():
+    with pytest.raises(ValidationError):
+        WantedSlot(
+            id="33333333-3333-3333-3333-333333333333",
+            kind=WantedKind.ONE_SHOT,
+            start_time="08:00",
+            end_time="10:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+            notify=None,
+            status=WantedStatus.PENDING,
+            attempts=[],
+            created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+            updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_recurring_slot_missing_day_of_week_rejected():
+    with pytest.raises(ValidationError):
+        WantedSlot(
+            id="44444444-4444-4444-4444-444444444444",
+            kind=WantedKind.RECURRING,
+            start_time="08:00",
+            end_time="10:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+            notify=None,
+            status=WantedStatus.PENDING,
+            attempts=[],
+            created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+            updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_patch_request_rejects_end_before_start_when_both_provided():
+    with pytest.raises(ValidationError):
+        PatchWantedRequest(start_time="10:00", end_time="08:00")

--- a/api/tests/test_wanted_models.py
+++ b/api/tests/test_wanted_models.py
@@ -1,0 +1,114 @@
+"""Tests for wanted-slot pydantic models."""
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.wanted import (
+    Attempt,
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    Notify,
+    Outcome,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
+
+
+def _one_shot(**over) -> WantedSlot:
+    base = dict(
+        id="11111111-1111-1111-1111-111111111111",
+        kind=WantedKind.ONE_SHOT,
+        target_date=datetime.date(2026, 6, 1),
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="encrypted-blob",
+        notify=Notify(to="+15550001111", from_="+15550002222"),
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+def test_wanted_slot_json_roundtrip_preserves_fields():
+    slot = _one_shot()
+    restored = WantedSlot.model_validate_json(slot.model_dump_json())
+    assert restored == slot
+    assert restored.notify.from_ == "+15550002222"
+
+
+def test_recurring_slot_requires_day_of_week():
+    slot = WantedSlot(
+        id="22222222-2222-2222-2222-222222222222",
+        kind=WantedKind.RECURRING,
+        day_of_week=5,  # Saturday (Monday=0)
+        start_time="07:00",
+        end_time="09:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    assert slot.day_of_week == 5
+    assert slot.target_date is None
+
+
+def test_create_one_shot_request_rejects_end_before_start():
+    with pytest.raises(ValidationError):
+        CreateOneShotRequest(
+            target_date=datetime.date(2026, 6, 1),
+            start_time="10:00",
+            end_time="08:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+        )
+
+
+def test_create_recurring_request_validates_day_of_week_range():
+    with pytest.raises(ValidationError):
+        CreateRecurringRequest(
+            day_of_week=7,
+            start_time="08:00",
+            end_time="10:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+        )
+
+
+def test_wanted_response_redacts_credentials():
+    slot = _one_shot()
+    resp = WantedResponse.from_slot(slot)
+    dumped = resp.model_dump()
+    assert "credentials" not in dumped
+    assert dumped["has_credentials"] is True
+    assert dumped["notify"]["to"] == "+15550001111"
+
+
+def test_patch_request_all_fields_optional():
+    patch = PatchWantedRequest()
+    assert patch.model_dump(exclude_unset=True) == {}
+
+
+def test_attempt_and_outcome_enum_serialize():
+    att = Attempt(
+        ts=datetime.datetime(2026, 5, 24, tzinfo=datetime.timezone.utc),
+        target_date=datetime.date(2026, 6, 1),
+        outcome=Outcome.BOOKED,
+        booking_id="bk-1",
+    )
+    assert att.model_dump()["outcome"] == "booked"

--- a/api/tests/test_wanted_routes.py
+++ b/api/tests/test_wanted_routes.py
@@ -5,7 +5,6 @@ from fakeredis import aioredis
 from fastapi.testclient import TestClient
 
 from app.dependencies import get_current_session, get_wanted_store
-from app.main import create_app
 from app.services.wanted_store import WantedStore
 
 
@@ -14,6 +13,8 @@ def client():
     from app.config import get_settings
 
     get_settings.cache_clear()
+    from app.main import create_app
+
     app = create_app()
     redis = aioredis.FakeRedis(decode_responses=True)
     store = WantedStore(redis)

--- a/api/tests/test_wanted_routes.py
+++ b/api/tests/test_wanted_routes.py
@@ -1,0 +1,110 @@
+"""Endpoint tests for the /api/wanted CRUD router."""
+
+import datetime
+
+import pytest
+from fakeredis import aioredis
+
+from app.dependencies import get_current_session, get_wanted_store
+from app.main import create_app
+from app.services.wanted_store import WantedStore
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    app = create_app()
+    redis = aioredis.FakeRedis(decode_responses=True)
+    store = WantedStore(redis)
+
+    app.dependency_overrides[get_current_session] = lambda: {"base_url": "x"}
+    app.dependency_overrides[get_wanted_store] = lambda: store
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+def _one_shot_body(**over):
+    body = dict(
+        target_date="2026-06-01",
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="enc-blob",
+    )
+    body.update(over)
+    return body
+
+
+def test_create_one_shot_returns_redacted_record(client):
+    r = client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    assert r.status_code == 201, r.text
+    data = r.json()
+    assert data["kind"] == "one_shot"
+    assert data["has_credentials"] is True
+    assert "credentials" not in data
+    assert data["status"] == "pending"
+
+
+def test_create_recurring_and_list(client):
+    client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    client.post(
+        "/api/wanted?kind=recurring",
+        json={
+            "day_of_week": 5,
+            "start_time": "07:00",
+            "end_time": "09:00",
+            "num_slots": 1,
+            "partners": [],
+            "credentials": "blob",
+        },
+    )
+    r = client.get("/api/wanted")
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+def test_get_single_and_404(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    assert client.get(f"/api/wanted/{created['id']}").status_code == 200
+    assert client.get("/api/wanted/missing").status_code == 404
+
+
+def test_patch_updates_mutable_fields(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    r = client.patch(
+        f"/api/wanted/{created['id']}",
+        json={"disabled": True, "start_time": "09:00"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "disabled"
+    assert body["start_time"] == "09:00"
+
+
+def test_patch_reenable_sets_pending(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    client.patch(f"/api/wanted/{created['id']}", json={"disabled": True})
+    r = client.patch(f"/api/wanted/{created['id']}", json={"disabled": False})
+    assert r.json()["status"] == "pending"
+
+
+def test_delete(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    assert client.delete(f"/api/wanted/{created['id']}").status_code == 204
+    assert client.get(f"/api/wanted/{created['id']}").status_code == 404
+
+
+def test_list_filters_by_status(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    client.patch(f"/api/wanted/{created['id']}", json={"disabled": True})
+    client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    r = client.get("/api/wanted?status=disabled")
+    assert len(r.json()) == 1

--- a/api/tests/test_wanted_routes.py
+++ b/api/tests/test_wanted_routes.py
@@ -1,14 +1,12 @@
 """Endpoint tests for the /api/wanted CRUD router."""
 
-import datetime
-
 import pytest
 from fakeredis import aioredis
+from fastapi.testclient import TestClient
 
 from app.dependencies import get_current_session, get_wanted_store
 from app.main import create_app
 from app.services.wanted_store import WantedStore
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -68,7 +66,9 @@ def test_create_recurring_and_list(client):
     )
     r = client.get("/api/wanted")
     assert r.status_code == 200
-    assert len(r.json()) == 2
+    records = r.json()
+    assert len(records) == 2
+    assert {rec["kind"] for rec in records} == {"one_shot", "recurring"}
 
 
 def test_get_single_and_404(client):
@@ -108,3 +108,22 @@ def test_list_filters_by_status(client):
     client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
     r = client.get("/api/wanted?status=disabled")
     assert len(r.json()) == 1
+
+
+def test_create_one_shot_missing_target_date_returns_422(client):
+    body = _one_shot_body()
+    del body["target_date"]
+    r = client.post("/api/wanted?kind=one_shot", json=body)
+    assert r.status_code == 422
+
+
+def test_create_with_no_body_returns_422(client):
+    r = client.post("/api/wanted?kind=one_shot")
+    assert r.status_code == 422
+
+
+def test_patch_into_invalid_window_returns_422(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    # stored end_time is 10:00; patch start_time past it
+    r = client.patch(f"/api/wanted/{created['id']}", json={"start_time": "11:00"})
+    assert r.status_code == 422

--- a/api/tests/test_wanted_routes.py
+++ b/api/tests/test_wanted_routes.py
@@ -116,6 +116,8 @@ def test_create_one_shot_missing_target_date_returns_422(client):
     del body["target_date"]
     r = client.post("/api/wanted?kind=one_shot", json=body)
     assert r.status_code == 422
+    # ErrorResponse.detail is a str (PR review): not a list of error dicts.
+    assert isinstance(r.json()["detail"], str)
 
 
 def test_create_with_no_body_returns_422(client):
@@ -128,3 +130,23 @@ def test_patch_into_invalid_window_returns_422(client):
     # stored end_time is 10:00; patch start_time past it
     r = client.patch(f"/api/wanted/{created['id']}", json={"start_time": "11:00"})
     assert r.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "patch_body",
+    [
+        {"day_of_week": 2},
+        {"kind": "recurring"},
+        {"target_date": "2026-07-01"},
+        {"unknown_field": "x"},
+    ],
+)
+def test_patch_immutable_or_unknown_field_returns_422(client, patch_body):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    r = client.patch(f"/api/wanted/{created['id']}", json=patch_body)
+    assert r.status_code == 422
+    # The record must be unchanged after a rejected patch.
+    after = client.get(f"/api/wanted/{created['id']}").json()
+    assert after["kind"] == "one_shot"
+    assert after["day_of_week"] is None
+    assert after["target_date"] == created["target_date"]

--- a/api/tests/test_wanted_store.py
+++ b/api/tests/test_wanted_store.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_asyncio
 from fakeredis import aioredis
 
-from app.models.wanted import Notify, WantedKind, WantedSlot, WantedStatus
+from app.models.wanted import WantedKind, WantedSlot, WantedStatus
 from app.services.wanted_store import WantedStore
 
 
@@ -78,3 +78,10 @@ async def test_one_shot_gets_ttl_recurring_does_not(store: WantedStore):
                              target_date=None, day_of_week=5))
     assert await store.redis.ttl("wanted:one") > 0
     assert await store.redis.ttl("wanted:rec") == -1
+
+
+def test_ttl_seconds_is_pinned_relative_to_today():
+    from fakeredis import aioredis
+    s = WantedStore(aioredis.FakeRedis(decode_responses=True))
+    slot = _slot("t", target_date=datetime.date(2026, 6, 1))
+    assert s._ttl_seconds(slot, today=datetime.date(2026, 5, 16)) == 46 * 24 * 3600

--- a/api/tests/test_wanted_store.py
+++ b/api/tests/test_wanted_store.py
@@ -1,0 +1,80 @@
+"""Tests for WantedStore Redis persistence."""
+
+import datetime
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis
+
+from app.models.wanted import Notify, WantedKind, WantedSlot, WantedStatus
+from app.services.wanted_store import WantedStore
+
+
+def _slot(slot_id: str, **over) -> WantedSlot:
+    base = dict(
+        id=slot_id,
+        kind=WantedKind.ONE_SHOT,
+        target_date=datetime.date(2026, 6, 1),
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+@pytest_asyncio.fixture
+async def store() -> WantedStore:
+    redis = aioredis.FakeRedis(decode_responses=True)
+    yield WantedStore(redis)
+    await redis.aclose()
+
+
+async def test_create_then_get(store: WantedStore):
+    slot = _slot("a")
+    await store.create(slot)
+    fetched = await store.get("a")
+    assert fetched == slot
+
+
+async def test_get_missing_returns_none(store: WantedStore):
+    assert await store.get("nope") is None
+
+
+async def test_list_all_returns_every_created_slot(store: WantedStore):
+    await store.create(_slot("a"))
+    await store.create(_slot("b"))
+    ids = {s.id for s in await store.list_all()}
+    assert ids == {"a", "b"}
+
+
+async def test_delete_removes_record_and_index_entry(store: WantedStore):
+    await store.create(_slot("a"))
+    assert await store.delete("a") is True
+    assert await store.get("a") is None
+    assert await store.list_all() == []
+    assert await store.delete("a") is False
+
+
+async def test_update_persists_changes(store: WantedStore):
+    await store.create(_slot("a"))
+    slot = await store.get("a")
+    slot.status = WantedStatus.BOOKED
+    await store.update(slot)
+    assert (await store.get("a")).status == WantedStatus.BOOKED
+
+
+async def test_one_shot_gets_ttl_recurring_does_not(store: WantedStore):
+    await store.create(_slot("one", kind=WantedKind.ONE_SHOT,
+                             target_date=datetime.date(2026, 6, 1)))
+    await store.create(_slot("rec", kind=WantedKind.RECURRING,
+                             target_date=None, day_of_week=5))
+    assert await store.redis.ttl("wanted:one") > 0
+    assert await store.redis.ttl("wanted:rec") == -1

--- a/api/tests/test_worker.py
+++ b/api/tests/test_worker.py
@@ -1,0 +1,189 @@
+"""Tests for the wanted-slot worker run_once orchestration."""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis
+
+from app.models.domain import TimeSlot
+from app.models.wanted import (
+    Notify,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.booking_client import BookingError, LoginError
+from app.services.scheduling import RELEASE_WINDOW_DAYS
+from app.services.wanted_store import WantedStore
+from app.services.worker import run_once
+
+TODAY = datetime.date(2026, 5, 16)
+RELEASE = TODAY + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+
+
+def _slot(slot_id="a", **over) -> WantedSlot:
+    base = dict(
+        id=slot_id,
+        kind=WantedKind.ONE_SHOT,
+        target_date=RELEASE,
+        start_time="08:00",
+        end_time="12:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="enc",
+        notify=Notify(to="+15550001111"),
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+@pytest_asyncio.fixture
+async def store():
+    redis = aioredis.FakeRedis(decode_responses=True)
+    yield WantedStore(redis)
+    await redis.aclose()
+
+
+def _bookable(t):
+    return TimeSlot(time=t, can_book=True, booking_form={"f": "1"})
+
+
+def _make_client(slots, *, book_id="bk-9", login_exc=None,
+                 book_exc=None, avail_exc=None):
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    if login_exc:
+        client.login.side_effect = login_exc
+    if avail_exc:
+        client.get_availability.side_effect = avail_exc
+    else:
+        client.get_availability.return_value = slots
+    if book_exc:
+        client.book_time_slot.side_effect = book_exc
+    else:
+        client.book_time_slot.return_value = book_id
+    client.add_partner.return_value = True
+    return client
+
+
+def _deps(client, *, decrypt=("user", "pin")):
+    enc = MagicMock()
+    enc.decrypt_credentials.return_value = decrypt
+    notifier = MagicMock()
+    return dict(
+        client_factory=lambda base_url, **_: client,
+        encryption=enc,
+        notifier=notifier,
+        base_url="https://golf.example.com",
+        today=TODAY,
+    )
+
+
+async def test_successful_booking_marks_one_shot_booked(store):
+    await store.create(_slot())
+    client = _make_client([_bookable("09:00"), _bookable("10:00")])
+    deps = _deps(client)
+    await run_once(store, **deps)
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.BOOKED
+    assert updated.attempts[-1].outcome is Outcome.BOOKED
+    assert updated.attempts[-1].booking_id == "bk-9"
+    client.book_time_slot.assert_awaited_once()
+    client.add_partner.assert_awaited_once()
+    deps["notifier"].send.assert_called_once()
+
+
+async def test_no_slots_in_window_records_no_slots_keeps_pending(store):
+    await store.create(_slot())
+    client = _make_client([TimeSlot(time="09:00", can_book=False, booking_form={})])
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.PENDING
+    assert updated.attempts[-1].outcome is Outcome.NO_SLOTS
+
+
+async def test_login_failure_records_auth_failed(store):
+    await store.create(_slot())
+    client = _make_client([], login_exc=LoginError("bad creds"))
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.attempts[-1].outcome is Outcome.AUTH_FAILED
+    assert updated.status is WantedStatus.PENDING
+
+
+async def test_one_shot_past_target_marked_expired_no_attempt(store):
+    await store.create(_slot(target_date=TODAY - datetime.timedelta(days=1)))
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.EXPIRED
+    client.book_time_slot.assert_not_awaited()
+
+
+async def test_partner_failure_is_tolerated(store):
+    await store.create(_slot(partners=["p1", "p2"]))
+    client = _make_client([_bookable("09:00")])
+    client.add_partner.side_effect = [True, BookingError("partner busy")]
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.BOOKED
+
+
+async def test_one_failing_record_does_not_block_others(store):
+    await store.create(_slot("a"))
+    await store.create(_slot("b"))
+    calls = {"n": 0}
+
+    def factory(base_url, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _make_client([], avail_exc=Exception("boom"))
+        return _make_client([_bookable("09:00")])
+
+    enc = MagicMock()
+    enc.decrypt_credentials.return_value = ("u", "p")
+    await run_once(
+        store,
+        client_factory=factory,
+        encryption=enc,
+        notifier=MagicMock(),
+        base_url="https://x",
+        today=TODAY,
+    )
+    statuses = {s.id: s.status for s in await store.list_all()}
+    assert WantedStatus.BOOKED in statuses.values()
+
+
+async def test_recurring_records_attempt_stays_pending(store):
+    await store.create(
+        _slot("r", kind=WantedKind.RECURRING, target_date=None,
+              day_of_week=RELEASE.weekday())
+    )
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    updated = await store.get("r")
+    assert updated.status is WantedStatus.PENDING
+    assert updated.attempts[-1].outcome is Outcome.BOOKED
+    assert updated.attempts[-1].target_date == RELEASE
+
+
+async def test_second_run_same_day_is_idempotent_for_recurring(store):
+    await store.create(
+        _slot("r", kind=WantedKind.RECURRING, target_date=None,
+              day_of_week=RELEASE.weekday())
+    )
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    client2 = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client2))
+    updated = await store.get("r")
+    assert len(updated.attempts) == 1
+    client2.book_time_slot.assert_not_awaited()

--- a/api/tests/test_worker.py
+++ b/api/tests/test_worker.py
@@ -3,7 +3,6 @@
 import datetime
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 import pytest_asyncio
 from fakeredis import aioredis
 
@@ -187,3 +186,29 @@ async def test_second_run_same_day_is_idempotent_for_recurring(store):
     updated = await store.get("r")
     assert len(updated.attempts) == 1
     client2.book_time_slot.assert_not_awaited()
+
+
+async def test_store_update_failure_for_one_slot_does_not_block_others(store):
+    await store.create(_slot("a"))
+    await store.create(_slot("b"))
+
+    real_update = store.update
+    calls = {"n": 0}
+
+    async def flaky_update(slot):
+        # Fail the persist for whichever slot is processed first.
+        if calls["n"] == 0:
+            calls["n"] += 1
+            raise RuntimeError("redis down")
+        await real_update(slot)
+
+    store.update = flaky_update
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+
+    store.update = real_update
+    statuses = {s.id: s.status for s in await store.list_all()}
+    # Exactly one slot persisted as BOOKED; the other was attempted but its
+    # persist failed — the run did NOT abort, both were processed.
+    assert list(statuses.values()).count(WantedStatus.BOOKED) == 1
+    assert calls["n"] == 1

--- a/api/tests/test_worker.py
+++ b/api/tests/test_worker.py
@@ -212,3 +212,26 @@ async def test_store_update_failure_for_one_slot_does_not_block_others(store):
     # persist failed — the run did NOT abort, both were processed.
     assert list(statuses.values()).count(WantedStatus.BOOKED) == 1
     assert calls["n"] == 1
+
+
+async def test_expire_path_persist_failure_does_not_block_others(store):
+    # Stale one-shot -> expire path; its store.update fails. A second, due
+    # one-shot must still be processed (run not aborted).
+    await store.create(_slot("a", target_date=TODAY - datetime.timedelta(days=1)))
+    await store.create(_slot("b", target_date=RELEASE))
+
+    real_update = store.update
+
+    async def flaky_update(slot):
+        if slot.id == "a":  # the expire-path persist
+            raise RuntimeError("redis down")
+        await real_update(slot)
+
+    store.update = flaky_update
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    store.update = real_update
+
+    assert (await store.get("b")).status is WantedStatus.BOOKED
+    # 'a' expire persist failed, so it stays PENDING in the store (not aborted).
+    assert (await store.get("a")).status is WantedStatus.PENDING

--- a/charts/tee-sniper-api/templates/worker-cronjob.yaml
+++ b/charts/tee-sniper-api/templates/worker-cronjob.yaml
@@ -21,6 +21,7 @@ spec:
             {{- include "tee-sniper-api.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: worker
         spec:
+          # Never: fresh pod per attempt; idempotent worker tolerates waiting for the next schedule
           restartPolicy: Never
           serviceAccountName: {{ include "tee-sniper-api.serviceAccountName" . }}
           automountServiceAccountToken: false

--- a/charts/tee-sniper-api/templates/worker-cronjob.yaml
+++ b/charts/tee-sniper-api/templates/worker-cronjob.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.worker.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tee-sniper-api.fullname" . }}-worker
+  labels:
+    {{- include "tee-sniper-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  schedule: {{ .Values.worker.schedule | quote }}
+  suspend: {{ .Values.worker.suspend | default false }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            {{- include "tee-sniper-api.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: worker
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "tee-sniper-api.serviceAccountName" . }}
+          automountServiceAccountToken: false
+          containers:
+            - name: worker
+              image: {{ include "tee-sniper-api.apiImage" . | quote }}
+              imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+              command: ["python", "-m", "app.cli.worker"]
+              envFrom:
+                - configMapRef:
+                    name: {{ include "tee-sniper-api.fullname" . }}-config
+              env:
+                - name: TSA_SHARED_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.api.existingSecret }}
+                      key: shared-secret
+                {{- if .Values.redis.enabled }}
+                - name: TSA_REDIS_HOST
+                  value: {{ printf "%s-redis-master" .Release.Name | quote }}
+                - name: TSA_REDIS_PORT
+                  value: "6379"
+                - name: TSA_REDIS_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.redis.auth.existingSecret }}
+                      key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+                - name: TSA_REDIS_URL
+                  value: "redis://:$(TSA_REDIS_PASSWORD)@$(TSA_REDIS_HOST):$(TSA_REDIS_PORT)/0"
+                {{- end }}
+                {{- if .Values.worker.twilio.enabled }}
+                - name: TSA_TWILIO_ACCOUNT_SID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-account-sid
+                - name: TSA_TWILIO_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-auth-token
+                - name: TSA_TWILIO_FROM_NUMBER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-from-number
+                {{- end }}
+              resources:
+                {{- toYaml .Values.worker.resources | nindent 16 }}
+{{- end }}

--- a/charts/tee-sniper-api/values.schema.json
+++ b/charts/tee-sniper-api/values.schema.json
@@ -100,6 +100,22 @@
         "create": { "type": "boolean" },
         "name": { "type": "string" }
       }
+    },
+    "worker": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "suspend": { "type": "boolean" },
+        "resources": { "type": "object" },
+        "twilio": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingSecret": { "type": "string" }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/tee-sniper-api/values.schema.json
+++ b/charts/tee-sniper-api/values.schema.json
@@ -105,14 +105,14 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "schedule": { "type": "string" },
+        "schedule": { "type": "string", "minLength": 1 },
         "suspend": { "type": "boolean" },
         "resources": { "type": "object" },
         "twilio": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "existingSecret": { "type": "string" }
+            "existingSecret": { "type": "string", "minLength": 1 }
           }
         }
       }

--- a/charts/tee-sniper-api/values.yaml
+++ b/charts/tee-sniper-api/values.yaml
@@ -31,6 +31,22 @@ cli:
 
 cronjobs: []
 
+worker:
+  enabled: false
+  schedule: "30 6 * * *"
+  suspend: false
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 500m
+  # Twilio is only required when wanted-slots use SMS notify.
+  twilio:
+    enabled: false
+    existingSecret: tee-sniper-api
+
 redis:
   enabled: true
   architecture: standalone

--- a/charts/tee-sniper-api/values.yaml
+++ b/charts/tee-sniper-api/values.yaml
@@ -32,6 +32,9 @@ cli:
 cronjobs: []
 
 worker:
+  # The worker shares the API's Redis. When worker.enabled=true you must
+  # also have redis.enabled=true, OR supply TSA_REDIS_URL via the chart's
+  # secret/config — otherwise the worker connects to localhost and fails.
   enabled: false
   schedule: "30 6 * * *"
   suspend: false

--- a/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
+++ b/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
@@ -31,6 +31,14 @@ All commands below are run from the **repository root** unless stated.
 
 ## 1. Start the stack
 
+> **Heads-up if you run this from a git worktree.** Compose derives the
+> project name from the directory, so a worktree (`wanted-tee-times`) is a
+> *different* stack than the main repo (`tee-sniper`). Two stacks both publish
+> host port `6379`, so a redis still running from the other copy will block
+> this one (`port is already allocated`, or the API logging
+> `Error -2 connecting to redis:6379. Name or service not known`). See
+> **Troubleshooting** at the bottom before filing a bug.
+
 ```bash
 docker compose up -d
 docker compose ps
@@ -321,3 +329,46 @@ index no longer lists the deleted id.
 - [ ] Worker runs end-to-end and records an attempt
 - [ ] (Optional) live booking / idempotency / SMS
 - [ ] Delete returns 204; record gone from index
+
+---
+
+## Troubleshooting
+
+### API logs `Error -2 connecting to redis:6379. Name or service not known`, or `Bind for 0.0.0.0:6379 failed: port is already allocated`
+
+Both symptoms have the same cause: **another Compose stack's redis is using
+host port 6379.** Compose names the project after the directory, so running
+from a git worktree (`wanted-tee-times`) is a *different* project than the
+main checkout (`tee-sniper`) — two redis containers, one host port.
+Leftover/partial `up` runs can also leave a redis detached from the network.
+
+Diagnose:
+
+```bash
+# What holds host port 6379?
+docker ps -a --filter "publish=6379" \
+  --format '{{.Names}}  {{.Image}}  {{.Status}}'
+# Is THIS project's redis actually attached to its network? ([] = the bug)
+docker inspect "$(docker compose ps -q redis)" \
+  --format '{{json .NetworkSettings.Networks}}'
+```
+
+Fix — stop the conflicting stack's redis (data is in its volume, preserved),
+then cleanly recreate this one:
+
+```bash
+docker stop tee-sniper-redis-1          # the other project's redis; reversible
+docker compose down --remove-orphans
+docker compose up -d
+```
+
+Verify:
+
+```bash
+docker compose exec -T api python3 -c "import socket; print(socket.gethostbyname('redis'))"
+curl -s http://localhost:8000/health | python3 -m json.tool   # redis_connected: true
+```
+
+Restore the other stack later with `docker start tee-sniper-redis-1` (or run
+only one repo copy's Compose stack at a time). This is local Docker state, not
+an application bug — the Compose file and app config are correct.

--- a/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
+++ b/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
@@ -1,0 +1,322 @@
+# Manual Test Guide — Wanted Tee-Times
+
+A step-by-step manual verification of the API locally, focused on the new
+**wanted tee-times** feature (and the daily worker), plus a baseline check
+that the existing app/API still works.
+
+> ⚠️ **Live booking warning.** The booking endpoints and the worker talk to
+> the **real** booking site using your real credentials. Steps that can make a
+> real reservation are clearly marked **[LIVE]**. The wanted-slot CRUD steps
+> (create/list/get/patch/delete) are side-effect-free. The worker step is
+> designed so you can verify the whole pipeline **without** making a real
+> booking by choosing a target date with no availability.
+
+---
+
+## 0. Prerequisites
+
+- Docker running.
+- A `.env` file at the repo root with **real** values:
+
+  ```
+  TSA_SHARED_SECRET=<any strong secret string>
+  TSA_BASE_URL=https://<your-booking-site>/
+  ```
+- Valid booking-site credentials (member ID + PIN).
+- `python3` available (used only to encrypt credentials and pretty-print JSON).
+
+All commands below are run from the **repository root** unless stated.
+
+---
+
+## 1. Start the stack
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Expect both `api` and `redis` services `running` / `healthy`. The dev override
+auto-loads (`Dockerfile.dev`, hot-reload, text logs, `TSA_DEBUG=true`).
+
+Tail logs in a second terminal so you can watch requests and the worker:
+
+```bash
+docker compose logs -f api
+```
+
+---
+
+## 2. Health check
+
+```bash
+curl -s http://localhost:8000/health | python3 -m json.tool
+```
+
+**Pass:** HTTP 200, `"status": "healthy"`, `"redis_connected": true`.
+If `redis_connected` is false, sessions and wanted-slots won't work — stop and
+fix Redis first.
+
+---
+
+## 3. Encrypt credentials & log in
+
+The API never takes a plaintext PIN; it expects the same AES-256-GCM blob
+format used everywhere. Generate it with the project's `EncryptionService`:
+
+```bash
+export TSA_SHARED_SECRET="$(grep -E '^TSA_SHARED_SECRET=' .env | cut -d= -f2-)"
+read -r -p "Member ID: " MEMBER_ID
+read -r -s -p "PIN: " PIN; echo
+
+ENCRYPTED=$(TSA_SECRET="$TSA_SHARED_SECRET" U="$MEMBER_ID" P="$PIN" \
+  python3 -c "import os,sys; sys.path.insert(0,'api'); \
+from app.services.encryption import EncryptionService; \
+print(EncryptionService(os.environ['TSA_SECRET']).encrypt_credentials(os.environ['U'],os.environ['P']))")
+
+echo "Encrypted blob length: ${#ENCRYPTED}"
+```
+
+> If the import fails, run it via the API venv instead:
+> `api/.venv/bin/python3 -c "..."` (same snippet, drop the `sys.path.insert`).
+
+Log in and capture the bearer token:
+
+```bash
+LOGIN=$(curl -s -X POST http://localhost:8000/api/login \
+  -H 'Content-Type: application/json' \
+  -d "{\"credentials\": \"$ENCRYPTED\"}")
+echo "$LOGIN" | python3 -m json.tool
+TOKEN=$(echo "$LOGIN" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+echo "TOKEN=$TOKEN"
+```
+
+**Pass:** HTTP 200, an `access_token` and `expires_at` returned, `TOKEN` set.
+
+---
+
+## 4. Baseline regression — existing endpoints still work
+
+Confirm the new router didn't break the existing API.
+
+```bash
+# Configured partners (auth required)
+curl -s http://localhost:8000/api/partners \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+
+# Availability for ~8 days out (slots release 8 days before play)
+DATE=$(python3 -c "import datetime; print((datetime.date.today()+datetime.timedelta(days=8)).isoformat())")
+curl -s "http://localhost:8000/api/$DATE/times" \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+```
+
+**Pass:** `/api/partners` returns a (possibly empty) list; `/api/{date}/times`
+returns `total_count` / `filtered_count` and a `times` array (HTTP 200).
+
+---
+
+## 5. Wanted tee-times — CRUD (safe, no booking side effects)
+
+### 5a. Create a one-shot request
+
+Pick a target date inside the bookable window so the worker would consider it
+"due" (today ≤ target ≤ today+8). The `credentials` field is the **same
+encrypted blob** from step 3.
+
+```bash
+TARGET=$(python3 -c "import datetime; print((datetime.date.today()+datetime.timedelta(days=8)).isoformat())")
+
+CREATE=$(curl -s -X POST "http://localhost:8000/api/wanted?kind=one_shot" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"target_date\":\"$TARGET\",\"start_time\":\"08:00\",\"end_time\":\"10:00\",\"num_slots\":1,\"partners\":[],\"credentials\":\"$ENCRYPTED\"}")
+echo "$CREATE" | python3 -m json.tool
+WANTED_ID=$(echo "$CREATE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "WANTED_ID=$WANTED_ID"
+```
+
+**Pass:** HTTP 201. In the response body verify:
+- `"kind": "one_shot"`, `"status": "pending"`, `"target_date"` matches.
+- `"has_credentials": true` **and there is NO `credentials` field** (redaction).
+
+### 5b. Create a recurring request
+
+```bash
+# day_of_week: Monday=0 … Sunday=6
+curl -s -X POST "http://localhost:8000/api/wanted?kind=recurring" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"day_of_week\":5,\"start_time\":\"07:00\",\"end_time\":\"09:00\",\"num_slots\":2,\"partners\":[],\"credentials\":\"$ENCRYPTED\"}" \
+  | python3 -m json.tool
+```
+
+**Pass:** HTTP 201, `"kind": "recurring"`, `"day_of_week": 5`, `target_date` null.
+
+### 5c. List & filter
+
+```bash
+curl -s http://localhost:8000/api/wanted \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+curl -s "http://localhost:8000/api/wanted?status=pending" \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+```
+
+**Pass:** the list contains both records; the `?status=pending` filter returns
+them too; no `credentials` field on any item.
+
+### 5d. Get one / 404
+
+```bash
+curl -s "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+curl -s -o /dev/null -w "%{http_code}\n" \
+  "http://localhost:8000/api/wanted/does-not-exist" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Pass:** the first returns the record (200, with empty `attempts`); the
+second prints `404`.
+
+### 5e. Patch — update window, then disable & re-enable
+
+```bash
+curl -s -X PATCH "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"start_time":"09:00","disabled":true}' | python3 -m json.tool
+
+curl -s -X PATCH "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"disabled":false}' | python3 -m json.tool
+```
+
+**Pass:** first response `"status": "disabled"` and `"start_time": "09:00"`;
+second response `"status": "pending"` (re-enabled).
+
+### 5f. Validation (expect 422, not 500)
+
+```bash
+# Missing target_date for a one-shot
+curl -s -o /dev/null -w "%{http_code}\n" -X POST \
+  "http://localhost:8000/api/wanted?kind=one_shot" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"start_time":"08:00","end_time":"10:00","credentials":"x"}'
+
+# Patch into an invalid window (start after stored end)
+curl -s -o /dev/null -w "%{http_code}\n" -X PATCH \
+  "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"start_time":"23:00"}'
+```
+
+**Pass:** both print `422` (clean validation error, **not** 500).
+
+---
+
+## 6. Inspect Redis (optional)
+
+Confirm persistence and the index set:
+
+```bash
+docker compose exec redis redis-cli KEYS 'wanted:*'
+docker compose exec redis redis-cli SMEMBERS wanted:index
+docker compose exec redis redis-cli TTL "wanted:$WANTED_ID"   # one-shot: >0 (≈ target+30d)
+```
+
+**Pass:** a `wanted:<id>` key per request, all ids present in `wanted:index`,
+the one-shot key has a positive TTL.
+
+---
+
+## 7. Run the worker
+
+The worker logs in, finds a slot in the window, and **books it for real**.
+To verify the **full pipeline without a real booking**, first point the
+one-shot at a date with **no availability** so the outcome is `no_slots`.
+
+### 7a. Safe pipeline test (no booking)
+
+```bash
+# A date far in the future is not yet bookable -> no slots -> no booking made,
+# but login + availability fetch + decision + attempt recording all execute.
+FUTURE=$(python3 -c "import datetime; print((datetime.date.today()+datetime.timedelta(days=8)).isoformat())")
+# (Use a real near-term date whose tee sheet you know is full/empty, or keep
+#  the default 8-days-out date and a narrow window unlikely to have slots.)
+
+docker compose exec api python -m app.cli.worker
+```
+
+Watch the `docker compose logs -f api` output for
+`Worker run starting` … `Worker run finished`. Then inspect the record:
+
+```bash
+curl -s "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+```
+
+**Pass (safe path):** `attempts` now has one entry with an `outcome` such as
+`no_slots`, `auth_failed`, or `upstream_error`; `status` is still `pending`
+(one-shot is not consumed on a non-booking outcome). This proves the
+end-to-end worker pipeline runs.
+
+> If `outcome` is `auth_failed`, the credentials blob in the wanted record
+> didn't decrypt — confirm you used the **same** `$ENCRYPTED` value and the
+> same `TSA_SHARED_SECRET` the API container runs with.
+
+### 7b. **[LIVE]** Real booking via the worker (only if you intend to book)
+
+If you want to verify an actual booking: set the one-shot's window to a time
+you know is bookable on a date within the 8-day release window, then run
+`docker compose exec api python -m app.cli.worker` again. On success the
+record's `status` becomes `booked` and the latest `attempt` has
+`outcome: booked` with a `booking_id`. **This is a real reservation —
+cancel it on the booking site afterwards if it was only a test.**
+
+Idempotency check: run the worker a second time the same day — a recurring
+slot must **not** re-book the same occurrence (no new `booked` attempt for the
+same `target_date`); a one-shot already `booked` is skipped.
+
+### 7c. SMS notification (optional)
+
+If you want to test SMS, recreate a wanted slot with a `notify` block and set
+the Twilio env (`TSA_TWILIO_ACCOUNT_SID`, `TSA_TWILIO_AUTH_TOKEN`,
+`TSA_TWILIO_FROM_NUMBER`) on the API/worker container:
+
+```json
+{ "...": "...", "notify": { "to": "+1555...", "from": "+1555..." } }
+```
+
+**Pass:** an SMS is received on success or terminal failure. With Twilio env
+unset, the worker must run fine and simply send nothing (no error).
+
+---
+
+## 8. Clean up
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X DELETE \
+  "http://localhost:8000/api/wanted/$WANTED_ID" \
+  -H "Authorization: Bearer $TOKEN"          # expect 204
+
+curl -s http://localhost:8000/api/wanted \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool   # delete the recurring one too
+
+docker compose down            # add -v to also wipe the redis volume
+```
+
+**Pass:** delete returns `204`; a second GET of the id returns `404`; the
+index no longer lists the deleted id.
+
+---
+
+## Result checklist
+
+- [ ] Health 200, Redis connected
+- [ ] Login returns a token
+- [ ] Existing `/api/partners` and `/api/{date}/times` still work
+- [ ] Create one-shot & recurring (201, credentials redacted)
+- [ ] List / status filter / get / 404
+- [ ] Patch updates window; disable→`disabled`; re-enable→`pending`
+- [ ] Invalid input returns 422 (not 500)
+- [ ] Redis holds `wanted:*` keys + `wanted:index`; one-shot has TTL
+- [ ] Worker runs end-to-end and records an attempt
+- [ ] (Optional) live booking / idempotency / SMS
+- [ ] Delete returns 204; record gone from index

--- a/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
+++ b/docs/MANUAL_TEST_WANTED_TEE_TIMES.md
@@ -62,23 +62,24 @@ fix Redis first.
 ## 3. Encrypt credentials & log in
 
 The API never takes a plaintext PIN; it expects the same AES-256-GCM blob
-format used everywhere. Generate it with the project's `EncryptionService`:
+format used everywhere. Generate it with the helper script
+`api/encrypt_credentials.py` (it reads `TSA_SHARED_SECRET` from `--secret`,
+the environment, or the repo-root `.env`):
 
 ```bash
-export TSA_SHARED_SECRET="$(grep -E '^TSA_SHARED_SECRET=' .env | cut -d= -f2-)"
-read -r -p "Member ID: " MEMBER_ID
-read -r -s -p "PIN: " PIN; echo
+# Prompts for member ID and PIN (PIN input is hidden):
+ENCRYPTED=$(api/.venv/bin/python api/encrypt_credentials.py)
 
-ENCRYPTED=$(TSA_SECRET="$TSA_SHARED_SECRET" U="$MEMBER_ID" P="$PIN" \
-  python3 -c "import os,sys; sys.path.insert(0,'api'); \
-from app.services.encryption import EncryptionService; \
-print(EncryptionService(os.environ['TSA_SECRET']).encrypt_credentials(os.environ['U'],os.environ['P']))")
+# Or non-interactively:
+# ENCRYPTED=$(api/.venv/bin/python api/encrypt_credentials.py -u <MEMBER_ID> -p <PIN>)
 
 echo "Encrypted blob length: ${#ENCRYPTED}"
 ```
 
-> If the import fails, run it via the API venv instead:
-> `api/.venv/bin/python3 -c "..."` (same snippet, drop the `sys.path.insert`).
+> No venv? `python3 api/encrypt_credentials.py` works too, as long as the
+> `cryptography` package is importable. Run `api/.venv/bin/python
+> api/encrypt_credentials.py --curl` to also print a ready-to-paste
+> `{"credentials": "..."}` JSON body. See `--help` for all options.
 
 Log in and capture the bearer token:
 

--- a/docs/superpowers/plans/2026-05-16-wanted-tee-times.md
+++ b/docs/superpowers/plans/2026-05-16-wanted-tee-times.md
@@ -1,0 +1,2037 @@
+# Wanted Tee-Times Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user register persisted "wanted tee-time" requests (one-shot by date, or recurring by day-of-week) that a daily worker attempts to book, records outcomes for, and optionally SMS-notifies on.
+
+**Architecture:** New Redis-backed `WantedStore`, a pure `is_due()` scheduling predicate, a `run_once()` worker orchestrator that logs in fresh per request via the existing `BookingClient`, a CRUD router under `/api/wanted`, and a `python -m app.cli.worker` entrypoint deployed as an opt-in Helm CronJob using the API image.
+
+**Tech Stack:** Python 3.11, FastAPI, pydantic v2, redis.asyncio, Twilio Python SDK, pytest / pytest-asyncio, fakeredis, Helm.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `api/app/models/wanted.py` (create) | Enums, `Attempt`, `Notify`, `WantedSlot` storage model, create/patch request models, `WantedResponse` (credential-redacted) |
+| `api/app/services/wanted_store.py` (create) | Redis CRUD + `wanted:index` SET management + one-shot TTL |
+| `api/app/services/scheduling.py` (create) | Pure `is_due(record, today)` predicate + `target_for(record, today)` |
+| `api/app/services/notifications.py` (create) | Twilio SMS helper, no-op when unconfigured |
+| `api/app/services/worker.py` (create) | `run_once()` orchestration: scan → decide → attempt → record → notify |
+| `api/app/cli/__init__.py` (create) | empty package marker |
+| `api/app/cli/worker.py` (create) | `python -m app.cli.worker` entrypoint |
+| `api/app/routers/wanted.py` (create) | REST CRUD endpoints |
+| `api/app/dependencies.py` (modify) | Extract framework-free factories for store/redis reuse |
+| `api/app/config.py` (modify) | Add optional Twilio settings |
+| `api/app/routers/__init__.py` (modify) | Export `wanted_router` |
+| `api/app/main.py` (modify) | Register `wanted_router` |
+| `api/requirements.txt` (modify) | Add `twilio`, `fakeredis` (test) |
+| `api/tests/test_*.py` (create) | One test module per new unit |
+| `charts/tee-sniper-api/templates/worker-cronjob.yaml` (create) | Opt-in worker CronJob (API image) |
+| `charts/tee-sniper-api/values.yaml` (modify) | `worker:` block |
+| `charts/tee-sniper-api/values.schema.json` (modify) | Schema for `worker:` block |
+| `README.md`, `CLAUDE.md` (modify) | Document feature; tick roadmap box; update spec status |
+
+Each task is committed independently. Run all commands from `api/` unless stated. Test runner: `.venv/bin/python -m pytest`.
+
+---
+
+## Task 1: Wanted-slot models
+
+**Files:**
+- Create: `api/app/models/wanted.py`
+- Test: `api/tests/test_wanted_models.py`
+- Modify: `api/app/models/__init__.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_wanted_models.py
+"""Tests for wanted-slot pydantic models."""
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.wanted import (
+    Attempt,
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    Notify,
+    Outcome,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
+
+
+def _one_shot(**over) -> WantedSlot:
+    base = dict(
+        id="11111111-1111-1111-1111-111111111111",
+        kind=WantedKind.ONE_SHOT,
+        target_date=datetime.date(2026, 6, 1),
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="encrypted-blob",
+        notify=Notify(to="+15550001111", from_="+15550002222"),
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+def test_wanted_slot_json_roundtrip_preserves_fields():
+    slot = _one_shot()
+    restored = WantedSlot.model_validate_json(slot.model_dump_json())
+    assert restored == slot
+    assert restored.notify.from_ == "+15550002222"
+
+
+def test_recurring_slot_requires_day_of_week():
+    slot = WantedSlot(
+        id="22222222-2222-2222-2222-222222222222",
+        kind=WantedKind.RECURRING,
+        day_of_week=5,  # Saturday (Monday=0)
+        start_time="07:00",
+        end_time="09:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    assert slot.day_of_week == 5
+    assert slot.target_date is None
+
+
+def test_create_one_shot_request_rejects_end_before_start():
+    with pytest.raises(ValidationError):
+        CreateOneShotRequest(
+            target_date=datetime.date(2026, 6, 1),
+            start_time="10:00",
+            end_time="08:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+        )
+
+
+def test_create_recurring_request_validates_day_of_week_range():
+    with pytest.raises(ValidationError):
+        CreateRecurringRequest(
+            day_of_week=7,
+            start_time="08:00",
+            end_time="10:00",
+            num_slots=1,
+            partners=[],
+            credentials="blob",
+        )
+
+
+def test_wanted_response_redacts_credentials():
+    slot = _one_shot()
+    resp = WantedResponse.from_slot(slot)
+    dumped = resp.model_dump()
+    assert "credentials" not in dumped
+    assert dumped["has_credentials"] is True
+    assert dumped["notify"]["to"] == "+15550001111"
+
+
+def test_patch_request_all_fields_optional():
+    patch = PatchWantedRequest()
+    assert patch.model_dump(exclude_unset=True) == {}
+
+
+def test_attempt_and_outcome_enum_serialize():
+    att = Attempt(
+        ts=datetime.datetime(2026, 5, 24, tzinfo=datetime.timezone.utc),
+        target_date=datetime.date(2026, 6, 1),
+        outcome=Outcome.BOOKED,
+        booking_id="bk-1",
+    )
+    assert att.model_dump()["outcome"] == "booked"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_models.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.models.wanted'`
+
+- [ ] **Step 3: Write the models**
+
+```python
+# api/app/models/wanted.py
+"""Pydantic models for wanted tee-time requests."""
+
+from __future__ import annotations
+
+import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class WantedKind(str, Enum):
+    ONE_SHOT = "one_shot"
+    RECURRING = "recurring"
+
+
+class WantedStatus(str, Enum):
+    PENDING = "pending"
+    BOOKED = "booked"
+    EXPIRED = "expired"
+    DISABLED = "disabled"
+
+
+class Outcome(str, Enum):
+    BOOKED = "booked"
+    NO_SLOTS = "no_slots"
+    AUTH_FAILED = "auth_failed"
+    UPSTREAM_ERROR = "upstream_error"
+    BOOKING_FAILED = "booking_failed"
+
+
+class Notify(BaseModel):
+    to: str = Field(..., description="Destination phone number, E.164")
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description="Sender number; falls back to server default when unset",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class Attempt(BaseModel):
+    ts: datetime.datetime
+    target_date: datetime.date
+    outcome: Outcome
+    booking_id: str | None = None
+    error: str | None = None
+
+
+_HHMM = r"^\d{2}:\d{2}$"
+
+
+class WantedSlot(BaseModel):
+    """Storage model persisted in Redis."""
+
+    id: str
+    kind: WantedKind
+    target_date: datetime.date | None = None
+    day_of_week: int | None = Field(default=None, ge=0, le=6)
+    end_date: datetime.date | None = None
+    start_time: str = Field(..., pattern=_HHMM)
+    end_time: str = Field(..., pattern=_HHMM)
+    num_slots: int = Field(..., ge=1, le=4)
+    partners: list[str] = Field(default_factory=list, max_length=3)
+    credentials: str
+    notify: Notify | None = None
+    status: WantedStatus = WantedStatus.PENDING
+    attempts: list[Attempt] = Field(default_factory=list)
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @model_validator(mode="after")
+    def _check_kind_fields(self) -> "WantedSlot":
+        if self.kind is WantedKind.ONE_SHOT and self.target_date is None:
+            raise ValueError("one_shot requires target_date")
+        if self.kind is WantedKind.RECURRING and self.day_of_week is None:
+            raise ValueError("recurring requires day_of_week")
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be after start_time")
+        return self
+
+
+class _CreateBase(BaseModel):
+    start_time: str = Field(..., pattern=_HHMM)
+    end_time: str = Field(..., pattern=_HHMM)
+    num_slots: int = Field(default=1, ge=1, le=4)
+    partners: list[str] = Field(default_factory=list, max_length=3)
+    credentials: str
+    notify: Notify | None = None
+
+    @model_validator(mode="after")
+    def _window(self):
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be after start_time")
+        return self
+
+
+class CreateOneShotRequest(_CreateBase):
+    target_date: datetime.date
+
+
+class CreateRecurringRequest(_CreateBase):
+    day_of_week: int = Field(..., ge=0, le=6)
+    end_date: datetime.date | None = None
+
+
+class PatchWantedRequest(BaseModel):
+    start_time: str | None = Field(default=None, pattern=_HHMM)
+    end_time: str | None = Field(default=None, pattern=_HHMM)
+    num_slots: int | None = Field(default=None, ge=1, le=4)
+    partners: list[str] | None = Field(default=None, max_length=3)
+    notify: Notify | None = None
+    disabled: bool | None = None
+    credentials: str | None = None
+
+
+class WantedResponse(BaseModel):
+    id: str
+    kind: WantedKind
+    target_date: datetime.date | None
+    day_of_week: int | None
+    end_date: datetime.date | None
+    start_time: str
+    end_time: str
+    num_slots: int
+    partners: list[str]
+    has_credentials: bool
+    notify: Notify | None
+    status: WantedStatus
+    attempts: list[Attempt]
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @classmethod
+    def from_slot(cls, slot: WantedSlot) -> "WantedResponse":
+        data = slot.model_dump()
+        data.pop("credentials")
+        data["has_credentials"] = bool(slot.credentials)
+        return cls(**data)
+```
+
+- [ ] **Step 4: Export from the models package**
+
+In `api/app/models/__init__.py`, add after the existing `from app.models.responses import (...)` block:
+
+```python
+from app.models.wanted import (
+    Attempt,
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    Notify,
+    Outcome,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
+```
+
+And append these names to the `__all__` list:
+
+```python
+    "Attempt",
+    "CreateOneShotRequest",
+    "CreateRecurringRequest",
+    "Notify",
+    "Outcome",
+    "PatchWantedRequest",
+    "WantedKind",
+    "WantedResponse",
+    "WantedSlot",
+    "WantedStatus",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_models.py -v`
+Expected: PASS (7 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/models/wanted.py api/app/models/__init__.py api/tests/test_wanted_models.py
+git commit -m "feat(api): add wanted-slot pydantic models"
+```
+
+---
+
+## Task 2: WantedStore Redis service
+
+**Files:**
+- Create: `api/app/services/wanted_store.py`
+- Test: `api/tests/test_wanted_store.py`
+- Modify: `api/requirements.txt`
+
+- [ ] **Step 1: Add fakeredis test dependency**
+
+In `api/requirements.txt`, under the `# Testing` section, add a new line after `pytest-httpx>=0.30.0`:
+
+```
+fakeredis>=2.21.0
+```
+
+Then install it:
+
+Run: `.venv/bin/python -m pip install "fakeredis>=2.21.0"`
+Expected: `Successfully installed fakeredis-...`
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# api/tests/test_wanted_store.py
+"""Tests for WantedStore Redis persistence."""
+
+import datetime
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis
+
+from app.models.wanted import Notify, WantedKind, WantedSlot, WantedStatus
+from app.services.wanted_store import WantedStore
+
+
+def _slot(slot_id: str, **over) -> WantedSlot:
+    base = dict(
+        id=slot_id,
+        kind=WantedKind.ONE_SHOT,
+        target_date=datetime.date(2026, 6, 1),
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+@pytest_asyncio.fixture
+async def store() -> WantedStore:
+    redis = aioredis.FakeRedis(decode_responses=True)
+    yield WantedStore(redis)
+    await redis.aclose()
+
+
+async def test_create_then_get(store: WantedStore):
+    slot = _slot("a")
+    await store.create(slot)
+    fetched = await store.get("a")
+    assert fetched == slot
+
+
+async def test_get_missing_returns_none(store: WantedStore):
+    assert await store.get("nope") is None
+
+
+async def test_list_all_returns_every_created_slot(store: WantedStore):
+    await store.create(_slot("a"))
+    await store.create(_slot("b"))
+    ids = {s.id for s in await store.list_all()}
+    assert ids == {"a", "b"}
+
+
+async def test_delete_removes_record_and_index_entry(store: WantedStore):
+    await store.create(_slot("a"))
+    assert await store.delete("a") is True
+    assert await store.get("a") is None
+    assert await store.list_all() == []
+    assert await store.delete("a") is False
+
+
+async def test_update_persists_changes(store: WantedStore):
+    await store.create(_slot("a"))
+    slot = await store.get("a")
+    slot.status = WantedStatus.BOOKED
+    await store.update(slot)
+    assert (await store.get("a")).status == WantedStatus.BOOKED
+
+
+async def test_one_shot_gets_ttl_recurring_does_not(store: WantedStore):
+    await store.create(_slot("one", kind=WantedKind.ONE_SHOT,
+                             target_date=datetime.date(2026, 6, 1)))
+    await store.create(_slot("rec", kind=WantedKind.RECURRING,
+                             target_date=None, day_of_week=5))
+    assert await store.redis.ttl("wanted:one") > 0
+    assert await store.redis.ttl("wanted:rec") == -1
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_store.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.wanted_store'`
+
+- [ ] **Step 4: Write the store**
+
+```python
+# api/app/services/wanted_store.py
+"""Redis persistence for wanted tee-time requests."""
+
+import datetime
+import logging
+
+from redis.asyncio import Redis
+
+from app.models.wanted import WantedKind, WantedSlot
+
+logger = logging.getLogger(__name__)
+
+
+class WantedStore:
+    """CRUD for WantedSlot records, with a set index for enumeration."""
+
+    KEY_PREFIX = "wanted:"
+    INDEX_KEY = "wanted:index"
+    ONE_SHOT_GRACE_DAYS = 30
+
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    def _key(self, slot_id: str) -> str:
+        return f"{self.KEY_PREFIX}{slot_id}"
+
+    def _ttl_seconds(self, slot: WantedSlot) -> int | None:
+        if slot.kind is not WantedKind.ONE_SHOT or slot.target_date is None:
+            return None
+        expiry = slot.target_date + datetime.timedelta(days=self.ONE_SHOT_GRACE_DAYS)
+        delta = expiry - datetime.date.today()
+        return max(int(delta.total_seconds()), 60)
+
+    async def create(self, slot: WantedSlot) -> None:
+        await self._write(slot)
+        await self.redis.sadd(self.INDEX_KEY, slot.id)
+        logger.info("Wanted slot created", extra={"id": slot.id, "kind": slot.kind.value})
+
+    async def update(self, slot: WantedSlot) -> None:
+        await self._write(slot)
+
+    async def _write(self, slot: WantedSlot) -> None:
+        ttl = self._ttl_seconds(slot)
+        payload = slot.model_dump_json()
+        if ttl is not None:
+            await self.redis.set(self._key(slot.id), payload, ex=ttl)
+        else:
+            await self.redis.set(self._key(slot.id), payload)
+
+    async def get(self, slot_id: str) -> WantedSlot | None:
+        raw = await self.redis.get(self._key(slot_id))
+        if raw is None:
+            return None
+        return WantedSlot.model_validate_json(raw)
+
+    async def list_all(self) -> list[WantedSlot]:
+        ids = await self.redis.smembers(self.INDEX_KEY)
+        result: list[WantedSlot] = []
+        for slot_id in ids:
+            slot = await self.get(slot_id)
+            if slot is None:
+                await self.redis.srem(self.INDEX_KEY, slot_id)  # prune expired
+                continue
+            result.append(slot)
+        return result
+
+    async def delete(self, slot_id: str) -> bool:
+        removed = await self.redis.delete(self._key(slot_id))
+        await self.redis.srem(self.INDEX_KEY, slot_id)
+        return removed > 0
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_store.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/services/wanted_store.py api/tests/test_wanted_store.py api/requirements.txt
+git commit -m "feat(api): add Redis-backed WantedStore"
+```
+
+---
+
+## Task 3: Scheduling predicate
+
+**Files:**
+- Create: `api/app/services/scheduling.py`
+- Test: `api/tests/test_scheduling.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_scheduling.py
+"""Tests for the is_due / target_for scheduling predicate."""
+
+import datetime
+
+from app.models.wanted import (
+    Attempt,
+    Notify,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.scheduling import RELEASE_WINDOW_DAYS, is_due, target_for
+
+TODAY = datetime.date(2026, 5, 16)  # a Saturday
+RELEASE = TODAY + datetime.timedelta(days=RELEASE_WINDOW_DAYS)  # 2026-05-24, Sunday
+
+
+def _slot(**over) -> WantedSlot:
+    base = dict(
+        id="x",
+        kind=WantedKind.ONE_SHOT,
+        target_date=RELEASE,
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=1,
+        partners=[],
+        credentials="blob",
+        notify=None,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+def test_one_shot_in_release_window_is_due():
+    assert is_due(_slot(target_date=RELEASE), TODAY) is True
+    assert target_for(_slot(target_date=RELEASE), TODAY) == RELEASE
+
+
+def test_one_shot_inside_8_day_window_is_due():
+    near = TODAY + datetime.timedelta(days=3)
+    assert is_due(_slot(target_date=near), TODAY) is True
+
+
+def test_one_shot_beyond_release_window_not_due():
+    far = RELEASE + datetime.timedelta(days=1)
+    assert is_due(_slot(target_date=far), TODAY) is False
+
+
+def test_one_shot_past_target_not_due():
+    past = TODAY - datetime.timedelta(days=1)
+    assert is_due(_slot(target_date=past), TODAY) is False
+
+
+def test_terminal_or_disabled_never_due():
+    assert is_due(_slot(status=WantedStatus.BOOKED), TODAY) is False
+    assert is_due(_slot(status=WantedStatus.EXPIRED), TODAY) is False
+    assert is_due(_slot(status=WantedStatus.DISABLED), TODAY) is False
+
+
+def _recurring(**over) -> WantedSlot:
+    return _slot(
+        kind=WantedKind.RECURRING,
+        target_date=None,
+        day_of_week=RELEASE.weekday(),
+        **over,
+    )
+
+
+def test_recurring_due_when_release_matches_day_of_week():
+    assert is_due(_recurring(), TODAY) is True
+    assert target_for(_recurring(), TODAY) == RELEASE
+
+
+def test_recurring_not_due_when_day_of_week_mismatch():
+    assert is_due(_recurring(day_of_week=(RELEASE.weekday() + 1) % 7), TODAY) is False
+
+
+def test_recurring_not_due_when_occurrence_already_booked():
+    booked = Attempt(
+        ts=datetime.datetime(2026, 5, 16, tzinfo=datetime.timezone.utc),
+        target_date=RELEASE,
+        outcome=Outcome.BOOKED,
+        booking_id="b1",
+    )
+    assert is_due(_recurring(attempts=[booked]), TODAY) is False
+
+
+def test_recurring_due_again_for_a_different_occurrence():
+    old = Attempt(
+        ts=datetime.datetime(2026, 5, 9, tzinfo=datetime.timezone.utc),
+        target_date=RELEASE - datetime.timedelta(days=7),
+        outcome=Outcome.BOOKED,
+        booking_id="b0",
+    )
+    assert is_due(_recurring(attempts=[old]), TODAY) is True
+
+
+def test_recurring_past_end_date_not_due():
+    assert is_due(_recurring(end_date=RELEASE - datetime.timedelta(days=1)), TODAY) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_scheduling.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.scheduling'`
+
+- [ ] **Step 3: Write the predicate**
+
+```python
+# api/app/services/scheduling.py
+"""Pure scheduling predicate: is a wanted slot due on a given day?"""
+
+import datetime
+
+from app.models.wanted import Outcome, WantedKind, WantedSlot, WantedStatus
+
+RELEASE_WINDOW_DAYS = 8
+
+
+def target_for(slot: WantedSlot, today: datetime.date) -> datetime.date | None:
+    """The play date this slot would attempt to book if run today."""
+    if slot.kind is WantedKind.ONE_SHOT:
+        return slot.target_date
+    release = today + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+    if release.weekday() != slot.day_of_week:
+        return None
+    return release
+
+
+def is_due(slot: WantedSlot, today: datetime.date) -> bool:
+    """True if the worker should attempt this slot today."""
+    if slot.status in (
+        WantedStatus.BOOKED,
+        WantedStatus.EXPIRED,
+        WantedStatus.DISABLED,
+    ):
+        return False
+
+    release = today + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+
+    if slot.kind is WantedKind.ONE_SHOT:
+        td = slot.target_date
+        return td is not None and today <= td <= release
+
+    # Recurring
+    target = target_for(slot, today)
+    if target is None:
+        return False
+    if slot.end_date is not None and target > slot.end_date:
+        return False
+    already_booked = any(
+        a.outcome is Outcome.BOOKED and a.target_date == target
+        for a in slot.attempts
+    )
+    return not already_booked
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_scheduling.py -v`
+Expected: PASS (11 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/services/scheduling.py api/tests/test_scheduling.py
+git commit -m "feat(api): add pure is_due scheduling predicate"
+```
+
+---
+
+## Task 4: Twilio notifications service
+
+**Files:**
+- Create: `api/app/services/notifications.py`
+- Test: `api/tests/test_notifications.py`
+- Modify: `api/requirements.txt`, `api/app/config.py`
+
+- [ ] **Step 1: Add the Twilio dependency**
+
+In `api/requirements.txt`, add a new section before `# Logging`:
+
+```
+# SMS notifications
+twilio>=9.0.0
+```
+
+Run: `.venv/bin/python -m pip install "twilio>=9.0.0"`
+Expected: `Successfully installed twilio-...`
+
+- [ ] **Step 2: Add Twilio settings to config**
+
+In `api/app/config.py`, add these fields to the `Settings` class immediately after the `partners_file` field:
+
+```python
+    # Twilio SMS (optional; required only when the worker sends notifications)
+    twilio_account_sid: str | None = None
+    twilio_auth_token: str | None = None
+    twilio_from_number: str | None = None
+```
+
+- [ ] **Step 3: Write the failing test**
+
+```python
+# api/tests/test_notifications.py
+"""Tests for the Twilio SMS notifier."""
+
+from unittest.mock import MagicMock
+
+from app.models.wanted import Notify
+from app.services.notifications import SmsNotifier
+
+
+def test_notifier_disabled_when_unconfigured_is_noop():
+    notifier = SmsNotifier(account_sid=None, auth_token=None, default_from=None)
+    # Must not raise and must not attempt to construct a client.
+    notifier.send(Notify(to="+15550001111"), "hello")
+    assert notifier.enabled is False
+
+
+def test_notifier_sends_with_explicit_from(monkeypatch):
+    fake_client = MagicMock()
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client  # inject
+    notifier.send(Notify(to="+15550001111", **{"from": "+15558888888"}), "booked!")
+    fake_client.messages.create.assert_called_once_with(
+        to="+15550001111", from_="+15558888888", body="booked!"
+    )
+
+
+def test_notifier_falls_back_to_default_from(monkeypatch):
+    fake_client = MagicMock()
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client
+    notifier.send(Notify(to="+15550001111"), "msg")
+    fake_client.messages.create.assert_called_once_with(
+        to="+15550001111", from_="+15559999999", body="msg"
+    )
+
+
+def test_notifier_swallows_send_errors(caplog):
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = RuntimeError("twilio down")
+    notifier = SmsNotifier(
+        account_sid="sid", auth_token="tok", default_from="+15559999999"
+    )
+    notifier._client = fake_client
+    # Must not raise — notification failure never aborts a booking.
+    notifier.send(Notify(to="+15550001111"), "msg")
+    assert "Failed to send SMS" in caplog.text
+
+
+def test_send_noop_when_notify_is_none():
+    notifier = SmsNotifier(account_sid="sid", auth_token="tok", default_from="+1")
+    notifier._client = MagicMock()
+    notifier.send(None, "msg")
+    notifier._client.messages.create.assert_not_called()
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_notifications.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.notifications'`
+
+- [ ] **Step 5: Write the notifier**
+
+```python
+# api/app/services/notifications.py
+"""Optional Twilio SMS notifications for the wanted-slot worker."""
+
+import logging
+
+from app.models.wanted import Notify
+
+logger = logging.getLogger(__name__)
+
+
+class SmsNotifier:
+    """Sends SMS via Twilio. A no-op when credentials are not configured.
+
+    Send failures are logged and swallowed: a notification problem must
+    never abort or fail a booking attempt.
+    """
+
+    def __init__(
+        self,
+        account_sid: str | None,
+        auth_token: str | None,
+        default_from: str | None,
+    ):
+        self._account_sid = account_sid
+        self._auth_token = auth_token
+        self._default_from = default_from
+        self._client = None
+        self.enabled = bool(account_sid and auth_token)
+
+    def _ensure_client(self):
+        if self._client is None:
+            from twilio.rest import Client
+
+            self._client = Client(self._account_sid, self._auth_token)
+        return self._client
+
+    def send(self, notify: Notify | None, body: str) -> None:
+        if notify is None or not self.enabled:
+            return
+        sender = notify.from_ or self._default_from
+        if not sender:
+            logger.warning("No 'from' number available; skipping SMS")
+            return
+        try:
+            client = self._ensure_client()
+            client.messages.create(to=notify.to, from_=sender, body=body)
+        except Exception as exc:  # noqa: BLE001 - never propagate
+            logger.warning("Failed to send SMS", extra={"error": str(exc)})
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_notifications.py tests/test_config.py -v`
+Expected: PASS (existing config tests still pass; 5 new pass)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/app/services/notifications.py api/tests/test_notifications.py api/requirements.txt api/app/config.py
+git commit -m "feat(api): add optional Twilio SMS notifier"
+```
+
+---
+
+## Task 5: Worker orchestration (run_once)
+
+**Files:**
+- Create: `api/app/services/worker.py`
+- Test: `api/tests/test_worker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_worker.py
+"""Tests for the wanted-slot worker run_once orchestration."""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fakeredis import aioredis
+
+from app.models.domain import TimeSlot
+from app.models.wanted import (
+    Notify,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.booking_client import BookingError, LoginError
+from app.services.scheduling import RELEASE_WINDOW_DAYS
+from app.services.wanted_store import WantedStore
+from app.services.worker import run_once
+
+TODAY = datetime.date(2026, 5, 16)
+RELEASE = TODAY + datetime.timedelta(days=RELEASE_WINDOW_DAYS)
+
+
+def _slot(slot_id="a", **over) -> WantedSlot:
+    base = dict(
+        id=slot_id,
+        kind=WantedKind.ONE_SHOT,
+        target_date=RELEASE,
+        start_time="08:00",
+        end_time="12:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="enc",
+        notify=Notify(to="+15550001111"),
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc),
+    )
+    base.update(over)
+    return WantedSlot(**base)
+
+
+@pytest_asyncio.fixture
+async def store():
+    redis = aioredis.FakeRedis(decode_responses=True)
+    yield WantedStore(redis)
+    await redis.aclose()
+
+
+def _bookable(t):
+    return TimeSlot(time=t, can_book=True, booking_form={"f": "1"})
+
+
+def _make_client(slots, *, book_id="bk-9", login_exc=None,
+                 book_exc=None, avail_exc=None):
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+    if login_exc:
+        client.login.side_effect = login_exc
+    if avail_exc:
+        client.get_availability.side_effect = avail_exc
+    else:
+        client.get_availability.return_value = slots
+    if book_exc:
+        client.book_time_slot.side_effect = book_exc
+    else:
+        client.book_time_slot.return_value = book_id
+    client.add_partner.return_value = True
+    return client
+
+
+def _deps(client, *, decrypt=("user", "pin")):
+    enc = MagicMock()
+    enc.decrypt_credentials.return_value = decrypt
+    notifier = MagicMock()
+    return dict(
+        client_factory=lambda base_url, **_: client,
+        encryption=enc,
+        notifier=notifier,
+        base_url="https://golf.example.com",
+        today=TODAY,
+    )
+
+
+async def test_successful_booking_marks_one_shot_booked(store):
+    await store.create(_slot())
+    client = _make_client([_bookable("09:00"), _bookable("10:00")])
+    deps = _deps(client)
+    await run_once(store, **deps)
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.BOOKED
+    assert updated.attempts[-1].outcome is Outcome.BOOKED
+    assert updated.attempts[-1].booking_id == "bk-9"
+    client.book_time_slot.assert_awaited_once()
+    client.add_partner.assert_awaited_once()
+    deps["notifier"].send.assert_called_once()
+
+
+async def test_no_slots_in_window_records_no_slots_keeps_pending(store):
+    await store.create(_slot())
+    client = _make_client([TimeSlot(time="09:00", can_book=False, booking_form={})])
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.PENDING
+    assert updated.attempts[-1].outcome is Outcome.NO_SLOTS
+
+
+async def test_login_failure_records_auth_failed(store):
+    await store.create(_slot())
+    client = _make_client([], login_exc=LoginError("bad creds"))
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.attempts[-1].outcome is Outcome.AUTH_FAILED
+    assert updated.status is WantedStatus.PENDING
+
+
+async def test_one_shot_past_target_marked_expired_no_attempt(store):
+    await store.create(_slot(target_date=TODAY - datetime.timedelta(days=1)))
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.EXPIRED
+    client.book_time_slot.assert_not_awaited()
+
+
+async def test_partner_failure_is_tolerated(store):
+    await store.create(_slot(partners=["p1", "p2"]))
+    client = _make_client([_bookable("09:00")])
+    client.add_partner.side_effect = [True, BookingError("partner busy")]
+    await run_once(store, **_deps(client))
+    updated = await store.get("a")
+    assert updated.status is WantedStatus.BOOKED
+
+
+async def test_one_failing_record_does_not_block_others(store):
+    await store.create(_slot("a"))
+    await store.create(_slot("b"))
+    calls = {"n": 0}
+
+    def factory(base_url, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _make_client([], avail_exc=Exception("boom"))
+        return _make_client([_bookable("09:00")])
+
+    enc = MagicMock()
+    enc.decrypt_credentials.return_value = ("u", "p")
+    await run_once(
+        store,
+        client_factory=factory,
+        encryption=enc,
+        notifier=MagicMock(),
+        base_url="https://x",
+        today=TODAY,
+    )
+    statuses = {s.id: s.status for s in await store.list_all()}
+    assert WantedStatus.BOOKED in statuses.values()
+
+
+async def test_recurring_records_attempt_stays_pending(store):
+    await store.create(
+        _slot("r", kind=WantedKind.RECURRING, target_date=None,
+              day_of_week=RELEASE.weekday())
+    )
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    updated = await store.get("r")
+    assert updated.status is WantedStatus.PENDING
+    assert updated.attempts[-1].outcome is Outcome.BOOKED
+    assert updated.attempts[-1].target_date == RELEASE
+
+
+async def test_second_run_same_day_is_idempotent_for_recurring(store):
+    await store.create(
+        _slot("r", kind=WantedKind.RECURRING, target_date=None,
+              day_of_week=RELEASE.weekday())
+    )
+    client = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client))
+    client2 = _make_client([_bookable("09:00")])
+    await run_once(store, **_deps(client2))
+    updated = await store.get("r")
+    assert len(updated.attempts) == 1
+    client2.book_time_slot.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_worker.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.worker'`
+
+- [ ] **Step 3: Write the worker**
+
+```python
+# api/app/services/worker.py
+"""Daily worker: scan wanted slots, attempt due ones, record outcomes."""
+
+import datetime
+import logging
+import random
+from collections.abc import Callable
+
+from app.models.wanted import (
+    Attempt,
+    Outcome,
+    WantedKind,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.booking_client import (
+    BookingClient,
+    BookingClientError,
+    BookingError,
+    LoginError,
+)
+from app.services.scheduling import is_due, target_for
+from app.services.wanted_store import WantedStore
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS_KEPT = 10
+
+ClientFactory = Callable[..., BookingClient]
+
+
+def _record(slot: WantedSlot, target: datetime.date, outcome: Outcome,
+            booking_id: str | None = None, error: str | None = None) -> Attempt:
+    att = Attempt(
+        ts=datetime.datetime.now(datetime.timezone.utc),
+        target_date=target,
+        outcome=outcome,
+        booking_id=booking_id,
+        error=error,
+    )
+    slot.attempts.append(att)
+    del slot.attempts[:-MAX_ATTEMPTS_KEPT]
+    slot.updated_at = att.ts
+    return att
+
+
+async def _attempt(slot: WantedSlot, target: datetime.date, *,
+                   client_factory: ClientFactory, encryption, base_url: str) -> Attempt:
+    try:
+        username, pin = encryption.decrypt_credentials(slot.credentials)
+    except Exception as exc:  # noqa: BLE001
+        return _record(slot, target, Outcome.AUTH_FAILED, error=str(exc))
+
+    client = client_factory(base_url=base_url)
+    try:
+        async with client:
+            try:
+                await client.login(username, pin)
+            except LoginError as exc:
+                return _record(slot, target, Outcome.AUTH_FAILED, error=str(exc))
+
+            client_date = target.strftime("%d-%m-%Y")
+            try:
+                slots = await client.get_availability(client_date)
+            except BookingClientError as exc:
+                return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+            candidates = [
+                s for s in slots
+                if s.can_book and slot.start_time <= s.time <= slot.end_time
+            ]
+            if not candidates:
+                return _record(slot, target, Outcome.NO_SLOTS)
+
+            chosen = random.choice(candidates)
+            try:
+                booking_id = await client.book_time_slot(chosen, slot.num_slots)
+            except BookingError as exc:
+                return _record(slot, target, Outcome.BOOKING_FAILED, error=str(exc))
+            except BookingClientError as exc:
+                return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+            for i, partner_id in enumerate(slot.partners):
+                try:
+                    await client.add_partner(booking_id, partner_id, i + 2)
+                except (BookingClientError, BookingError) as exc:
+                    logger.warning(
+                        "Failed to add partner",
+                        extra={"id": slot.id, "partner": partner_id,
+                               "error": str(exc)},
+                    )
+
+            return _record(slot, target, Outcome.BOOKED, booking_id=booking_id)
+    except Exception as exc:  # noqa: BLE001 - one record must not abort the run
+        return _record(slot, target, Outcome.UPSTREAM_ERROR, error=str(exc))
+
+
+async def run_once(
+    store: WantedStore,
+    *,
+    client_factory: ClientFactory,
+    encryption,
+    notifier,
+    base_url: str,
+    today: datetime.date | None = None,
+) -> None:
+    today = today or datetime.date.today()
+    slots = await store.list_all()
+    logger.info("Worker run starting", extra={"count": len(slots), "today": str(today)})
+
+    for slot in slots:
+        # Expire stale one-shots without an attempt.
+        if (
+            slot.kind is WantedKind.ONE_SHOT
+            and slot.status is WantedStatus.PENDING
+            and slot.target_date is not None
+            and slot.target_date < today
+        ):
+            slot.status = WantedStatus.EXPIRED
+            slot.updated_at = datetime.datetime.now(datetime.timezone.utc)
+            await store.update(slot)
+            continue
+
+        if not is_due(slot, today):
+            continue
+
+        target = target_for(slot, today)
+        if target is None:
+            continue
+
+        att = await _attempt(
+            slot, target,
+            client_factory=client_factory,
+            encryption=encryption,
+            base_url=base_url,
+        )
+
+        if att.outcome is Outcome.BOOKED and slot.kind is WantedKind.ONE_SHOT:
+            slot.status = WantedStatus.BOOKED
+
+        await store.update(slot)
+
+        if slot.notify is not None:
+            if att.outcome is Outcome.BOOKED:
+                body = (
+                    f"Booked tee time for {target.isoformat()} "
+                    f"({slot.num_slots} slot(s)). Booking {att.booking_id}."
+                )
+            else:
+                body = (
+                    f"Tee-time attempt for {target.isoformat()} "
+                    f"failed: {att.outcome.value}."
+                )
+            notifier.send(slot.notify, body)
+
+    logger.info("Worker run finished")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_worker.py -v`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/services/worker.py api/tests/test_worker.py
+git commit -m "feat(api): add wanted-slot worker run_once orchestration"
+```
+
+---
+
+## Task 6: Framework-free factories + CLI entrypoint
+
+**Files:**
+- Modify: `api/app/dependencies.py`
+- Create: `api/app/cli/__init__.py`, `api/app/cli/worker.py`
+- Test: `api/tests/test_cli_worker.py`
+
+- [ ] **Step 1: Add reusable factories to dependencies.py**
+
+In `api/app/dependencies.py`, add these functions after `get_partners_service` (around line 37). They construct objects without FastAPI's `Depends`, so the CLI can reuse them:
+
+```python
+def make_redis_client():
+    """Construct a standalone Redis client (no pooling) for CLI use."""
+    from redis.asyncio import Redis as _Redis
+
+    settings = get_settings()
+    return _Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def make_wanted_store(redis):
+    """Construct a WantedStore for the given Redis client."""
+    from app.services.wanted_store import WantedStore
+
+    return WantedStore(redis)
+
+
+def make_sms_notifier():
+    """Construct an SmsNotifier from settings."""
+    from app.services.notifications import SmsNotifier
+
+    settings = get_settings()
+    return SmsNotifier(
+        account_sid=settings.twilio_account_sid,
+        auth_token=settings.twilio_auth_token,
+        default_from=settings.twilio_from_number,
+    )
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# api/tests/test_cli_worker.py
+"""Tests for the CLI worker entrypoint wiring."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.cli.worker import main
+
+
+def test_main_wires_dependencies_and_invokes_run_once():
+    fake_redis = MagicMock()
+    fake_redis.aclose = AsyncMock()
+    fake_store = MagicMock()
+
+    with patch("app.cli.worker.make_redis_client", return_value=fake_redis), \
+         patch("app.cli.worker.make_wanted_store", return_value=fake_store), \
+         patch("app.cli.worker.make_sms_notifier", return_value=MagicMock()), \
+         patch("app.cli.worker.get_encryption_service", return_value=MagicMock()), \
+         patch("app.cli.worker.get_settings") as gs, \
+         patch("app.cli.worker.run_once", new=AsyncMock()) as run_once_mock:
+        gs.return_value.base_url = "https://golf.example.com"
+        main()
+
+    run_once_mock.assert_awaited_once()
+    _, kwargs = run_once_mock.call_args
+    assert kwargs["base_url"] == "https://golf.example.com"
+    assert "client_factory" in kwargs
+    fake_redis.aclose.assert_awaited_once()
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_cli_worker.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.cli'`
+
+- [ ] **Step 4: Create the CLI package and entrypoint**
+
+```python
+# api/app/cli/__init__.py
+"""Command-line entrypoints for tee-sniper-api."""
+```
+
+```python
+# api/app/cli/worker.py
+"""`python -m app.cli.worker` — run one wanted-slot booking pass."""
+
+import asyncio
+import logging
+import sys
+
+from app.config import get_settings
+from app.dependencies import (
+    get_encryption_service,
+    make_redis_client,
+    make_sms_notifier,
+    make_wanted_store,
+)
+from app.services.booking_client import BookingClient
+from app.services.worker import run_once
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    settings = get_settings()
+    redis = make_redis_client()
+    try:
+        store = make_wanted_store(redis)
+        await run_once(
+            store,
+            client_factory=lambda base_url, **_: BookingClient(base_url=base_url),
+            encryption=get_encryption_service(),
+            notifier=make_sms_notifier(),
+            base_url=settings.base_url,
+        )
+    finally:
+        await redis.aclose()
+
+
+def main() -> None:
+    logging.basicConfig(level=get_settings().log_level)
+    try:
+        asyncio.run(_run())
+    except Exception:  # noqa: BLE001
+        logger.exception("Worker run failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_cli_worker.py tests/test_dependencies.py -v`
+Expected: PASS (new test passes; existing dependency tests still pass)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/dependencies.py api/app/cli/ api/tests/test_cli_worker.py
+git commit -m "feat(api): add framework-free factories and CLI worker entrypoint"
+```
+
+---
+
+## Task 7: REST CRUD router
+
+**Files:**
+- Create: `api/app/routers/wanted.py`
+- Test: `api/tests/test_wanted_routes.py`
+- Modify: `api/app/routers/__init__.py`, `api/app/main.py`, `api/app/dependencies.py`
+
+- [ ] **Step 1: Add a request-scoped WantedStore dependency**
+
+In `api/app/dependencies.py`, add after `make_sms_notifier` (the function from Task 6):
+
+```python
+async def get_wanted_store(
+    redis: "Redis" = Depends(get_redis),
+) -> "WantedStore":
+    """Request-scoped WantedStore for the API router."""
+    from app.services.wanted_store import WantedStore
+
+    return WantedStore(redis)
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# api/tests/test_wanted_routes.py
+"""Endpoint tests for the /api/wanted CRUD router."""
+
+import datetime
+
+import pytest
+from fakeredis import aioredis
+
+from app.dependencies import get_current_session, get_wanted_store
+from app.main import create_app
+from app.services.wanted_store import WantedStore
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    app = create_app()
+    redis = aioredis.FakeRedis(decode_responses=True)
+    store = WantedStore(redis)
+
+    app.dependency_overrides[get_current_session] = lambda: {"base_url": "x"}
+    app.dependency_overrides[get_wanted_store] = lambda: store
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+def _one_shot_body(**over):
+    body = dict(
+        target_date="2026-06-01",
+        start_time="08:00",
+        end_time="10:00",
+        num_slots=2,
+        partners=["p1"],
+        credentials="enc-blob",
+    )
+    body.update(over)
+    return body
+
+
+def test_create_one_shot_returns_redacted_record(client):
+    r = client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    assert r.status_code == 201, r.text
+    data = r.json()
+    assert data["kind"] == "one_shot"
+    assert data["has_credentials"] is True
+    assert "credentials" not in data
+    assert data["status"] == "pending"
+
+
+def test_create_recurring_and_list(client):
+    client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    client.post(
+        "/api/wanted?kind=recurring",
+        json={
+            "day_of_week": 5,
+            "start_time": "07:00",
+            "end_time": "09:00",
+            "num_slots": 1,
+            "partners": [],
+            "credentials": "blob",
+        },
+    )
+    r = client.get("/api/wanted")
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+def test_get_single_and_404(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    assert client.get(f"/api/wanted/{created['id']}").status_code == 200
+    assert client.get("/api/wanted/missing").status_code == 404
+
+
+def test_patch_updates_mutable_fields(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    r = client.patch(
+        f"/api/wanted/{created['id']}",
+        json={"disabled": True, "start_time": "09:00"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "disabled"
+    assert body["start_time"] == "09:00"
+
+
+def test_patch_reenable_sets_pending(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    client.patch(f"/api/wanted/{created['id']}", json={"disabled": True})
+    r = client.patch(f"/api/wanted/{created['id']}", json={"disabled": False})
+    assert r.json()["status"] == "pending"
+
+
+def test_delete(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    assert client.delete(f"/api/wanted/{created['id']}").status_code == 204
+    assert client.get(f"/api/wanted/{created['id']}").status_code == 404
+
+
+def test_list_filters_by_status(client):
+    created = client.post("/api/wanted?kind=one_shot", json=_one_shot_body()).json()
+    client.patch(f"/api/wanted/{created['id']}", json={"disabled": True})
+    client.post("/api/wanted?kind=one_shot", json=_one_shot_body())
+    r = client.get("/api/wanted?status=disabled")
+    assert len(r.json()) == 1
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_routes.py -v`
+Expected: FAIL with `ImportError: cannot import name 'get_wanted_store'` or router 404s
+
+- [ ] **Step 4: Write the router**
+
+```python
+# api/app/routers/wanted.py
+"""CRUD endpoints for wanted tee-time requests."""
+
+import datetime
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+
+from app.dependencies import get_current_session, get_wanted_store
+from app.models.wanted import (
+    CreateOneShotRequest,
+    CreateRecurringRequest,
+    PatchWantedRequest,
+    WantedKind,
+    WantedResponse,
+    WantedSlot,
+    WantedStatus,
+)
+from app.services.wanted_store import WantedStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/wanted", tags=["Wanted"])
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+@router.post("", response_model=WantedResponse,
+             status_code=status.HTTP_201_CREATED)
+async def create_wanted(
+    kind: WantedKind = Query(...),
+    body: dict = None,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    if kind is WantedKind.ONE_SHOT:
+        req = CreateOneShotRequest.model_validate(body or {})
+        extra = dict(kind=kind, target_date=req.target_date)
+    else:
+        req = CreateRecurringRequest.model_validate(body or {})
+        extra = dict(kind=kind, day_of_week=req.day_of_week,
+                     end_date=req.end_date)
+
+    now = _now()
+    slot = WantedSlot(
+        id=str(uuid.uuid4()),
+        start_time=req.start_time,
+        end_time=req.end_time,
+        num_slots=req.num_slots,
+        partners=req.partners,
+        credentials=req.credentials,
+        notify=req.notify,
+        status=WantedStatus.PENDING,
+        attempts=[],
+        created_at=now,
+        updated_at=now,
+        **extra,
+    )
+    await store.create(slot)
+    return WantedResponse.from_slot(slot)
+
+
+@router.get("", response_model=list[WantedResponse])
+async def list_wanted(
+    status_filter: WantedStatus | None = Query(default=None, alias="status"),
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> list[WantedResponse]:
+    slots = await store.list_all()
+    if status_filter is not None:
+        slots = [s for s in slots if s.status is status_filter]
+    return [WantedResponse.from_slot(s) for s in slots]
+
+
+async def _require(store: WantedStore, slot_id: str) -> WantedSlot:
+    slot = await store.get(slot_id)
+    if slot is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Wanted slot not found")
+    return slot
+
+
+@router.get("/{slot_id}", response_model=WantedResponse)
+async def get_wanted(
+    slot_id: str,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    return WantedResponse.from_slot(await _require(store, slot_id))
+
+
+@router.patch("/{slot_id}", response_model=WantedResponse)
+async def patch_wanted(
+    slot_id: str,
+    patch: PatchWantedRequest,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> WantedResponse:
+    slot = await _require(store, slot_id)
+    fields = patch.model_dump(exclude_unset=True)
+
+    disabled = fields.pop("disabled", None)
+    for key, value in fields.items():
+        setattr(slot, key, value)
+
+    if disabled is True:
+        slot.status = WantedStatus.DISABLED
+    elif disabled is False and slot.status is WantedStatus.DISABLED:
+        slot.status = WantedStatus.PENDING
+
+    slot.updated_at = _now()
+    # Re-validate window/kind invariants by reconstructing.
+    slot = WantedSlot.model_validate(slot.model_dump())
+    await store.update(slot)
+    return WantedResponse.from_slot(slot)
+
+
+@router.delete("/{slot_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_wanted(
+    slot_id: str,
+    _session: dict = Depends(get_current_session),
+    store: WantedStore = Depends(get_wanted_store),
+) -> Response:
+    deleted = await store.delete(slot_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Wanted slot not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+```
+
+- [ ] **Step 5: Register the router**
+
+In `api/app/routers/__init__.py`, replace the contents with:
+
+```python
+"""API route handlers."""
+
+from app.routers.booking import router as booking_router
+from app.routers.wanted import router as wanted_router
+
+__all__ = ["booking_router", "wanted_router"]
+```
+
+In `api/app/main.py`, change the import line
+`from app.routers import booking_router` to:
+
+```python
+from app.routers import booking_router, wanted_router
+```
+
+and add after `app.include_router(booking_router)`:
+
+```python
+    app.include_router(wanted_router)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_wanted_routes.py -v`
+Expected: PASS (7 passed)
+
+- [ ] **Step 7: Full suite regression check**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS (all pre-existing tests still green)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/app/routers/wanted.py api/app/routers/__init__.py api/app/main.py api/app/dependencies.py api/tests/test_wanted_routes.py
+git commit -m "feat(api): add /api/wanted CRUD endpoints"
+```
+
+---
+
+## Task 8: Helm worker CronJob
+
+**Files:**
+- Create: `charts/tee-sniper-api/templates/worker-cronjob.yaml`
+- Modify: `charts/tee-sniper-api/values.yaml`, `charts/tee-sniper-api/values.schema.json`
+
+> Note: the existing `cronjob.yaml` template serves the **Go CLI** (`cli.image`, `TS_*` env). The worker uses the **API image** and `TSA_*` env, so it gets its own dedicated, opt-in template — do not modify `cronjob.yaml`.
+
+- [ ] **Step 1: Add the worker block to values.yaml**
+
+In `charts/tee-sniper-api/values.yaml`, add after the `cronjobs: []` line:
+
+```yaml
+worker:
+  enabled: false
+  schedule: "30 6 * * *"
+  suspend: false
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 500m
+  # Twilio is only required when wanted-slots use SMS notify.
+  twilio:
+    enabled: false
+    existingSecret: tee-sniper-api
+```
+
+- [ ] **Step 2: Create the CronJob template**
+
+```yaml
+# charts/tee-sniper-api/templates/worker-cronjob.yaml
+{{- if .Values.worker.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tee-sniper-api.fullname" . }}-worker
+  labels:
+    {{- include "tee-sniper-api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  schedule: {{ .Values.worker.schedule | quote }}
+  suspend: {{ .Values.worker.suspend | default false }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            {{- include "tee-sniper-api.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: worker
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "tee-sniper-api.serviceAccountName" . }}
+          automountServiceAccountToken: false
+          containers:
+            - name: worker
+              image: {{ include "tee-sniper-api.apiImage" . | quote }}
+              imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+              command: ["python", "-m", "app.cli.worker"]
+              envFrom:
+                - configMapRef:
+                    name: {{ include "tee-sniper-api.fullname" . }}-config
+              env:
+                - name: TSA_SHARED_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.api.existingSecret }}
+                      key: shared-secret
+                {{- if .Values.redis.enabled }}
+                - name: TSA_REDIS_HOST
+                  value: {{ printf "%s-redis-master" .Release.Name | quote }}
+                - name: TSA_REDIS_PORT
+                  value: "6379"
+                - name: TSA_REDIS_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.redis.auth.existingSecret }}
+                      key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+                - name: TSA_REDIS_URL
+                  value: "redis://:$(TSA_REDIS_PASSWORD)@$(TSA_REDIS_HOST):$(TSA_REDIS_PORT)/0"
+                {{- end }}
+                {{- if .Values.worker.twilio.enabled }}
+                - name: TSA_TWILIO_ACCOUNT_SID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-account-sid
+                - name: TSA_TWILIO_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-auth-token
+                - name: TSA_TWILIO_FROM_NUMBER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.worker.twilio.existingSecret }}
+                      key: twilio-from-number
+                {{- end }}
+              resources:
+                {{- toYaml .Values.worker.resources | nindent 16 }}
+{{- end }}
+```
+
+- [ ] **Step 3: Add the worker block to values.schema.json**
+
+Open `charts/tee-sniper-api/values.schema.json`. Inside the top-level
+`"properties"` object, add a `"worker"` key alongside the existing `"api"` /
+`"cli"` keys (match the file's existing indentation and add a comma after the
+preceding property):
+
+```json
+    "worker": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "suspend": { "type": "boolean" },
+        "resources": { "type": "object" },
+        "twilio": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingSecret": { "type": "string" }
+          }
+        }
+      }
+    }
+```
+
+- [ ] **Step 4: Lint and template-render the chart**
+
+Run: `helm lint charts/tee-sniper-api`
+Expected: `1 chart(s) linted, 0 chart(s) failed`
+
+Run: `helm template t charts/tee-sniper-api --set worker.enabled=true | grep -A2 "kind: CronJob"`
+Expected: output includes a CronJob named `t-tee-sniper-api-worker`
+
+Run: `helm template t charts/tee-sniper-api | grep -c "name: t-tee-sniper-api-worker" || true`
+Expected: `0` (worker absent when `worker.enabled` is false — opt-in confirmed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/tee-sniper-api/templates/worker-cronjob.yaml charts/tee-sniper-api/values.yaml charts/tee-sniper-api/values.schema.json
+git commit -m "feat(chart): add opt-in worker CronJob using the API image"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `README.md`, `CLAUDE.md`, `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`
+
+- [ ] **Step 1: Tick the roadmap box and add usage docs**
+
+In `README.md`, in the Roadmap section, change the first item from:
+
+```
+- [ ] **Wanted tee-times** — persisted booking requests (one-shot by date, or recurring by day-of-week) processed by a daily worker. Design: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+```
+
+to:
+
+```
+- [x] **Wanted tee-times** — persisted booking requests (one-shot by date, or recurring by day-of-week) processed by a daily worker. Design: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+```
+
+Then add a new subsection under the `## API Service` → `### API Endpoints`
+area (after the existing endpoint list) describing the new endpoints:
+
+```markdown
+#### Wanted tee-times
+
+Register a request to auto-book a slot when it becomes available:
+
+- `POST /api/wanted?kind=one_shot|recurring` — create a request
+- `GET /api/wanted[?status=pending|booked|expired|disabled]` — list requests
+- `GET /api/wanted/{id}` — fetch one (incl. attempt history)
+- `PATCH /api/wanted/{id}` — update window/partners/notify or disable
+- `DELETE /api/wanted/{id}` — remove
+
+A daily worker (`python -m app.cli.worker`, deployed as the opt-in
+`worker` Helm CronJob) processes due requests, books a matching slot, records
+the outcome, and optionally sends a Twilio SMS.
+```
+
+- [ ] **Step 2: Document the worker in CLAUDE.md**
+
+In `CLAUDE.md`, under the `### Testing` section's Python block, add:
+
+```bash
+# Run the wanted-slot worker once (needs TSA_* env, see config.py)
+cd api && .venv/bin/python -m app.cli.worker
+```
+
+And add a short section after the "API Migration Workflow" section:
+
+```markdown
+## Wanted Tee-Times
+
+Persisted auto-booking requests. Spec:
+`docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`.
+Plan: `docs/superpowers/plans/2026-05-16-wanted-tee-times.md`.
+
+- Models: `api/app/models/wanted.py`
+- Store: `api/app/services/wanted_store.py` (Redis `wanted:{id}` + `wanted:index`)
+- Scheduling predicate: `api/app/services/scheduling.py` (`is_due`, 8-day window)
+- Worker: `api/app/services/worker.py` (`run_once`), CLI `app/cli/worker.py`
+- Router: `api/app/routers/wanted.py` (`/api/wanted`)
+- Deploy: opt-in `worker` CronJob in `charts/tee-sniper-api`
+```
+
+- [ ] **Step 3: Flip the spec status**
+
+In `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`, change
+`**Status:** Draft` to `**Status:** Implemented`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CLAUDE.md docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md
+git commit -m "docs: document wanted tee-times feature"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the full test suite**
+
+Run: `cd api && .venv/bin/python -m pytest -q`
+Expected: all tests pass, including every new module.
+
+- [ ] **Lint check**
+
+Run: `cd api && .venv/bin/python -m ruff check app/`
+Expected: no errors in new files.
+
+- [ ] **Helm render sanity**
+
+Run: `helm template t charts/tee-sniper-api --set worker.enabled=true >/dev/null && echo OK`
+Expected: `OK`
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- Data model → Task 1 (all fields incl. `end_date`, `notify`, `attempts`, status enum). ✅
+- Redis storage + index + one-shot TTL → Task 2. ✅
+- Worker daily logic (one-shot in/out of window, past→expired, recurring DoW, idempotent re-run, end_date) → Tasks 3 & 5. ✅
+- Attempt logic + all outcomes (booked/no_slots/auth_failed/upstream_error/booking_failed) + partial partner tolerance → Task 5. ✅
+- Fresh login per attempt (no session reuse) → Task 5 `_attempt`. ✅
+- API surface (POST union/GET/GET one/PATCH mutable+immutable/DELETE, credential redaction) → Task 7. ✅
+- Always persist outcome; optional SMS on success and terminal failure → Tasks 4 & 5. ✅
+- Deployment: opt-in API-image CronJob, daily schedule, Twilio opt-in → Task 8. ✅
+- Testing matrix from spec → Tasks 1–7 test modules. ✅
+- Docs + roadmap tick + spec status → Task 9. ✅
+- Go removal explicitly out of scope → not in any task (correct per spec). ✅
+
+**Type consistency check:** `WantedSlot`, `WantedStatus`, `Outcome`, `Notify.from_` (alias `from`), `WantedResponse.from_slot`, `WantedStore.{create,get,update,delete,list_all}`, `is_due`/`target_for`, `run_once(store, *, client_factory, encryption, notifier, base_url, today)`, `SmsNotifier.send(notify, body)` — names used consistently across Tasks 1–8.
+
+**Placeholder scan:** none — every code/command step contains complete content.

--- a/docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md
+++ b/docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md
@@ -1,6 +1,6 @@
 # Wanted Tee-Times Design
 
-**Status:** Draft
+**Status:** Implemented
 **Date:** 2026-05-16
 **Related:** Extends `api/` (FastAPI service). Follow-up spec will decommission the Go CLI.
 

--- a/docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md
+++ b/docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md
@@ -1,0 +1,210 @@
+# Wanted Tee-Times Design
+
+**Status:** Draft
+**Date:** 2026-05-16
+**Related:** Extends `api/` (FastAPI service). Follow-up spec will decommission the Go CLI.
+
+## Goal
+
+Let a user register a "wanted tee-time": a persisted request to book a slot
+matching some criteria *when it becomes bookable*. A daily worker scans the
+registered requests, attempts the ones that are due, records the outcome, and
+optionally sends an SMS.
+
+Booking-site slots are released **8 days before play** (e.g. Saturday slots open
+the previous Friday). The worker runs once per day, just before release time.
+
+Two kinds of request:
+
+- **One-shot** — a single explicit `target_date`. May be created arbitrarily far
+  in advance; it lies dormant until its release window opens, is attempted, then
+  reaches a terminal state.
+- **Recurring** — a `day_of_week` pattern (optionally capped by `end_date`).
+  Re-attempted for each matching occurrence indefinitely until disabled/deleted.
+
+## Non-goals
+
+- **Removing the Go CLI.** A separate follow-up spec covers decommissioning
+  `cmd/tee-sniper/`, `pkg/`, `run-teesniper.sh`, and the Go CI. This spec only
+  builds the Python worker. However, the worker is deliberately designed at
+  **behavioural parity** with the Go CLI (login → find → filter by window →
+  random pick → book → add partners → SMS) so the later removal is a clean swap.
+- **Multi-user.** Still single-user. API session auth merely gates who can manage
+  requests; the encrypted credentials on each record are what the worker uses.
+- **MCP exposure.** Adding `create_wanted_slot` / `list_wanted_slots` / etc. MCP
+  tools is a follow-up.
+- **A UI.** Management is API-only (and MCP later).
+- **Per-request dynamic K8s CronJobs.** One fixed daily schedule for all requests.
+
+## Architecture
+
+```
+┌──────────────┐  REST /api/wanted   ┌──────────────┐
+│  API client  │ ──────────────────► │  FastAPI     │
+│  (curl/MCP)  │                     │  routers/    │
+└──────────────┘                     │  wanted.py   │
+                                     └──────┬───────┘
+                                            │  WantedStore (Redis: wanted:{id}, wanted:index)
+                                            ▼
+                                     ┌──────────────┐
+   K8s CronJob (daily) ────────────► │ cli/worker.py│ ── BookingClient ──► booking site
+   python -m app.cli.worker          │ run_once()   │ ── Twilio (optional SMS)
+                                     └──────────────┘
+```
+
+## Data model
+
+`WantedSlot`, stored in Redis at `wanted:{uuid}`, with every id also held in a
+`wanted:index` SET so the worker can enumerate without `KEYS`.
+
+| Field | Notes |
+|---|---|
+| `id` | UUID |
+| `kind` | `"one_shot"` \| `"recurring"` |
+| `target_date` | ISO date — **one-shot only** |
+| `day_of_week` | `mon`..`sun` — **recurring only** |
+| `end_date` | optional ISO date cap — recurring only |
+| `start_time` / `end_time` | `HH:MM` booking window |
+| `num_slots` | 1–4 |
+| `partners` | list of partner ids (may be empty) |
+| `credentials` | AES-256-GCM blob, identical format to `POST /api/login` |
+| `notify` | optional `{to, from}` E.164 phone numbers for SMS |
+| `status` | `pending` \| `booked` \| `expired` \| `disabled` |
+| `attempts` | bounded list (last ~10) of `{ts, target_date, outcome, booking_id?, error?}` |
+| `created_at` / `updated_at` | ISO timestamps |
+
+`status` semantics:
+
+- One-shot collapses to a terminal state: `booked` (succeeded) or `expired`
+  (`target_date` passed without success). `disabled` if the user pauses it.
+- Recurring stays `pending` until the user sets `disabled` or deletes it;
+  per-occurrence outcomes live in `attempts`.
+
+**TTL:** one-shot records get a Redis TTL ≈ 30 days past `target_date`; recurring
+records have no TTL (deleted explicitly). Index membership is pruned when a record
+expires or is deleted.
+
+Credentials are **never** returned in API responses — only a boolean "set".
+
+## Worker logic — one daily run
+
+`run_once()`:
+
+1. `today = date.today()`, `release_date = today + 8 days`.
+2. Enumerate `wanted:index`. For each record decide if **due today**:
+   - `disabled` or terminal (`booked`/`expired`) → skip.
+   - **One-shot:**
+     - `target_date < today` → set `status=expired`, skip.
+     - `today ≤ target_date ≤ release_date` → **due** (covers both the
+       normal "created early, window now open" case and the "created late,
+       already inside the 8-day window" case).
+     - `target_date > release_date` → not bookable yet; revisit tomorrow.
+   - **Recurring:**
+     - `end_date` set and `release_date > end_date` → skip (lapsed; leave as-is).
+     - due iff `release_date.weekday() == day_of_week` **and** no existing
+       `attempts` entry with `target_date == release_date` and `outcome == booked`.
+3. For each due record, run an **attempt** (below). Records are independent — one
+   record's failure never aborts the run.
+
+The recurring "already booked this occurrence" guard makes the daily run
+idempotent: a second run on the same day won't double-book.
+
+## Attempt logic
+
+Per due record (target date = `release_date`, or `target_date` for one-shots):
+
+1. Decrypt credentials → fresh `BookingClient.login()`. (No Redis session reuse —
+   sessions are far too short-lived for a once-a-day worker; login is cheap.)
+2. `get_availability(target_date)` → keep bookable slots within
+   `[start_time, end_time]`.
+3. Pick one **at random** (matches Go CLI; avoids contention on a single slot).
+4. `book_time_slot(slot, num_slots)`.
+5. For each `partners` id, `add_partner(...)`. Partial success tolerated —
+   mirrors existing `PATCH /api/bookings/{id}` semantics.
+6. Append an `attempts` entry; if one-shot success, set `status=booked`.
+7. Always persist the outcome. If `notify` set, send Twilio SMS (success **and**
+   terminal failure).
+
+**Outcomes recorded:**
+
+| Situation | `outcome` | One-shot effect | Recurring effect |
+|---|---|---|---|
+| Booked | `booked` | `status=booked` (terminal) | logged; occurrence done |
+| No slot in window | `no_slots` | stays `pending`, retried until `target_date` passes then `expired` | move on |
+| Login failed | `auth_failed` | stays `pending` (user fixes creds via PATCH) | retried next occurrence |
+| Upstream 5xx | `upstream_error` | stays `pending`, retry next day | retried |
+| Book call failed post-pick | `booking_failed` | stays `pending`, retry next day | retried |
+
+Each attempt is wrapped in its own try/except. No auto-disable on failure — the
+daily retry self-heals once the user fixes credentials or the site recovers.
+
+## API surface
+
+New router `app/routers/wanted.py`, prefix `/api/wanted`, all endpoints behind
+the existing session-auth dependency.
+
+- `POST /api/wanted` — create. Body is a discriminated union on `kind`:
+  - `one_shot`: `target_date, start_time, end_time, num_slots, partners,
+    credentials, notify?`
+  - `recurring`: `day_of_week, end_date?, start_time, end_time, num_slots,
+    partners, credentials, notify?`
+  - Returns the full record (credentials redacted).
+- `GET /api/wanted` — list all; optional `?status=` filter.
+- `GET /api/wanted/{id}` — one record incl. `attempts` history.
+- `PATCH /api/wanted/{id}` — mutable: `start_time, end_time, num_slots,
+  partners, notify, disabled, credentials`. Immutable: `kind, target_date,
+  day_of_week`.
+- `DELETE /api/wanted/{id}` — hard delete (also removes from index).
+
+## Code layout
+
+```
+api/app/
+  models/wanted.py        # pydantic: WantedSlot, Create*/Patch requests, Attempt, Outcome enum
+  services/
+    wanted_store.py       # Redis CRUD + index management
+    notifications.py      # Twilio SMS helper (new)
+    worker.py             # run_once(): scan → decide due → attempt → record
+  routers/wanted.py       # REST endpoints
+  cli/__init__.py
+  cli/worker.py           # `python -m app.cli.worker` entrypoint
+```
+
+Worker reuses `BookingClient`, `EncryptionService`, `PartnersService`, and the
+Redis wiring. `dependencies.py` factory functions are refactored so non-FastAPI
+consumers (the CLI worker) can construct the same objects without the request
+scope.
+
+## Deployment
+
+Helm additions in `charts/tee-sniper-api/`:
+
+- New `CronJob`: same image as the API, `command: ["python","-m","app.cli.worker"]`,
+  schedule from `values.yaml` (default `"30 6 * * *"` — tune to release time).
+- Twilio env vars (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and a configurable
+  default `from` number) become required **when the CronJob is enabled**.
+- Worker is **opt-in** via `values.yaml`, so existing deployments are unchanged
+  until explicitly turned on.
+- The CronJob can also be triggered ad hoc (`kubectl create job --from=cronjob/...`)
+  to force an immediate run — this is the equivalent of the Go CLI's
+  cron-passes-the-date invocation.
+
+## Testing
+
+- `wanted_store` CRUD + index integrity against fakeredis.
+- **Due-date decision logic exhaustively:** one-shot before window / in window /
+  past / already booked / disabled; recurring DoW match / DoW mismatch /
+  occurrence already booked / past `end_date`.
+- `worker.run_once` with a fake `BookingClient`: success, `no_slots`,
+  `auth_failed`, partial partner failure, multi-record run where one fails and
+  others still succeed, idempotent second-run-same-day.
+- `notifications` SMS helper with a mocked Twilio client (sends on success and
+  terminal failure; no-op when `notify` unset).
+- CRUD endpoint tests on the existing pytest infra, incl. credential redaction
+  and immutable-field rejection on PATCH.
+
+## Future direction (out of scope here)
+
+- Follow-up spec: delete the Go CLI and its CI once this worker is proven at
+  parity.
+- Follow-up: MCP tools for managing wanted-slots.


### PR DESCRIPTION
## Summary

Adds **wanted tee-times** — persisted booking requests that a daily worker fulfils when slots become bookable (the booking site releases slots 8 days before play).

- **Two request kinds:** one-shot (explicit date, can be scheduled arbitrarily far out) and recurring (day-of-week pattern, optional end-date cap).
- **REST CRUD** at `/api/wanted` (create with `?kind=`, list with `?status=` filter, get/patch/delete by id). Credentials stored as the same AES-256-GCM blob as `/api/login`, never returned in responses.
- **Daily worker** (`python -m app.cli.worker`): scans requests, expires stale one-shots, attempts due ones (fresh login → find slot in window → random pick → book → add partners), records bounded attempt history, idempotent per recurring occurrence, isolates per-slot failures so one bad request never aborts the run.
- **Optional Twilio SMS** notifier (no-op when unconfigured; never aborts a booking).
- **Opt-in Helm CronJob** using the API image, reusing the deployment's Redis/secret wiring; `worker.enabled=false` by default.
- Design + plan docs under `docs/superpowers/`; README/CLAUDE.md updated; Go CLI explicitly left in place (separate follow-up spec).

Built TDD across 9 reviewed tasks. +55 tests (190 passed, 7 skipped). The one failing test (`test_config.py::test_settings_has_defaults`) is a pre-existing `TSA_DEBUG` shell-env leak unrelated to this branch and failing at baseline before it.

## Test plan

- [ ] `cd api && .venv/bin/python -m pytest -q` — new suites (models, store, scheduling, notifications, worker, cli, routes) all green
- [ ] `helm lint charts/tee-sniper-api` and render with `--set worker.enabled=true` / `--set worker.twilio.enabled=true`
- [ ] Manual: create a one-shot and recurring via `/api/wanted`, run `python -m app.cli.worker` against a test booking site, verify outcome recorded and (optional) SMS
- [ ] Confirm `credentials` never appears in any `/api/wanted` response or logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)