### PR TITLE
Add wanted tee-time MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,10 +186,12 @@ cd mcp && uv run tee-sniper-mcp
 The MCP server is a stdio-only client of the REST API. It encrypts credentials
 locally with the same AES-256-GCM scheme as `api/app/services/encryption.py`,
 calls `/api/login` lazily, caches the bearer token in memory, and proxies four
-tools (`find_tee_times`, `book_tee_time`, `list_partners`, `add_partners`) to
-the existing endpoints. See `mcp/README.md` for the full tool reference,
-configuration env vars, time-of-day bands, and Claude Desktop / MetaMCP config
-snippets.
+booking tools (`find_tee_times`, `book_tee_time`, `list_partners`,
+`add_partners`) plus seven wanted-tee-time tools (`create_one_shot_wanted`,
+`create_recurring_wanted`, `list_wanted`, `get_wanted`, `update_wanted`,
+`set_wanted_enabled`, `delete_wanted`) to the existing endpoints. See
+`mcp/README.md` for the full tool reference, configuration env vars,
+time-of-day bands, and Claude Desktop / MetaMCP config snippets.
 
 **Key design choices (rationale in `docs/superpowers/specs/2026-05-03-local-mcp-server-design.md`):**
 
@@ -227,3 +229,4 @@ snippets.
 - Plan: `docs/superpowers/plans/2026-05-04-local-mcp-server.md`
 - Shipped via PR #71 (single PR covering all 5 phases — A: API endpoint,
   B: scaffold, C: tools, D: Docker+CI, E: docs).
+- Wanted tee-time MCP tools spec: `docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md`; plan: `docs/superpowers/plans/2026-05-19-wanted-tee-times-mcp-tools.md`.

--- a/docs/superpowers/plans/2026-05-19-wanted-tee-times-mcp-tools.md
+++ b/docs/superpowers/plans/2026-05-19-wanted-tee-times-mcp-tools.md
@@ -1,0 +1,1060 @@
+# Wanted Tee-Time MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 7 MCP tools that proxy the `/api/wanted` endpoints so an LLM/user can create, inspect, edit, pause, and delete persisted auto-booking ("wanted tee-time") requests from Claude Desktop / MetaMCP.
+
+**Architecture:** Extend the existing `Tools` class in `mcp/src/tee_sniper_mcp/tools.py`, register the new tools in `server.py`, and reuse the existing `ApiClient` (lazy login + 401 retry) and `dates.py` parsers. Credentials are auto-encrypted from config (same AES-GCM scheme as login); the LLM never sees them. Same return convention as existing tools: dict on success, `{"error": ...}` on failure, never raise.
+
+**Tech Stack:** Python 3.14, FastMCP, httpx, respx (test HTTP mocking), pytest, uv.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md`
+
+**Workflow:** Implement on a new git worktree taken from `main` (created via `superpowers:using-git-worktrees` at execution time). Ship as a single combined PR (project preference for multi-phase work). Subagents commit locally only; the controller handles push/PR.
+
+**Conventions confirmed against source:**
+- `day_of_week`: int `0–6`, **0 = Monday … 6 = Sunday**. Confirmed: `api/app/services/scheduling.py` compares `release.weekday() != slot.day_of_week`, and Python `date.weekday()` is 0=Mon..6=Sun. The `_WEEKDAYS` map already in `dates.py` (`monday:0 … sunday:6`) matches.
+- Test pattern: existing MCP tests use `respx` to mock HTTP at `http://api.test`, with a `tools` fixture wiring a real `ApiClient`/`AuthManager` over a mocked `/api/login`. New tests follow the same pattern.
+- `ApiClient` returns parsed JSON, or `None` when the response has no body (204). Errors raise `ApiError`; `auth` failures raise `AuthError` (wrapped to `ApiError`).
+- All `/api/wanted` endpoints are session-authed; `ApiClient` attaches the bearer token transparently.
+
+**Run tests:** `cd mcp && uv run pytest`
+
+---
+
+### Task 1: `parse_day_of_week` helper in dates.py
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/dates.py`
+- Test: `mcp/tests/test_dates.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_dates.py`:
+
+```python
+import pytest
+
+from tee_sniper_mcp.dates import DateParseError, parse_day_of_week
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("monday", 0),
+        ("Monday", 0),
+        (" MON ", 0),
+        ("sat", 5),
+        ("saturday", 5),
+        ("sunday", 6),
+        ("0", 0),
+        ("6", 6),
+        (0, 0),
+        (6, 6),
+    ],
+)
+def test_parse_day_of_week_ok(value, expected):
+    assert parse_day_of_week(value) == expected
+
+
+@pytest.mark.parametrize("value", ["funday", "", "7", "-1", 7, -1, "mondayy"])
+def test_parse_day_of_week_rejects_junk(value):
+    with pytest.raises(DateParseError):
+        parse_day_of_week(value)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_dates.py -k parse_day_of_week -v`
+Expected: FAIL — `ImportError: cannot import name 'parse_day_of_week'`
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `mcp/src/tee_sniper_mcp/dates.py` (after `parse_time`). Reuse the existing `_WEEKDAYS` map; add abbreviation support:
+
+```python
+_WEEKDAY_ABBR = {name[:3]: idx for name, idx in _WEEKDAYS.items()}
+
+
+def parse_day_of_week(value: str | int) -> int:
+    """Normalize a weekday to int 0-6 (0=Monday … 6=Sunday)."""
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise DateParseError(f"invalid day_of_week: {value!r}")
+    if isinstance(value, int):
+        if 0 <= value <= 6:
+            return value
+        raise DateParseError(f"day_of_week out of range (0-6): {value}")
+
+    s = value.strip().lower()
+    if not s:
+        raise DateParseError("empty day_of_week")
+    if s in _WEEKDAYS:
+        return _WEEKDAYS[s]
+    if s in _WEEKDAY_ABBR:
+        return _WEEKDAY_ABBR[s]
+    if s.lstrip("-").isdigit():
+        n = int(s)
+        if 0 <= n <= 6:
+            return n
+        raise DateParseError(f"day_of_week out of range (0-6): {s}")
+    raise DateParseError(f"unknown day_of_week '{value}'")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_dates.py -k parse_day_of_week -v`
+Expected: PASS (all parametrized cases)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/dates.py mcp/tests/test_dates.py
+git commit -m "feat(mcp): add parse_day_of_week helper"
+```
+
+---
+
+### Task 2: Shared test fixtures + `_summarize` helper
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Create: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mcp/tests/test_wanted_tools.py`:
+
+```python
+"""Tests for the wanted-tee-time MCP tools."""
+
+import datetime as dt
+
+import httpx
+import pytest
+import respx
+
+from tee_sniper_mcp.api_client import ApiClient
+from tee_sniper_mcp.auth import AuthManager
+from tee_sniper_mcp.config import Config
+from tee_sniper_mcp.tools import Tools
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        api_base_url="http://api.test",
+        username="alice",
+        pin="1234",
+        shared_secret="s3cret",
+        time_bands_override=None,
+    )
+
+
+def _login_response() -> httpx.Response:
+    expires = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=30)).isoformat()
+    return httpx.Response(200, json={"access_token": "tok-1", "expires_at": expires})
+
+
+@pytest.fixture
+async def tools(config: Config):
+    with respx.MockRouter(assert_all_called=False) as router:
+        router.post("http://api.test/api/login").mock(return_value=_login_response())
+        async with httpx.AsyncClient() as http:
+            api = ApiClient(config, AuthManager(config, http), http)
+            yield Tools(config=config, api=api, today=lambda: dt.date(2026, 5, 19))
+
+
+def _slot(**over) -> dict:
+    base = {
+        "id": "w-1",
+        "kind": "one_shot",
+        "target_date": "2026-05-27",
+        "day_of_week": None,
+        "end_date": None,
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "num_slots": 2,
+        "partners": ["p1"],
+        "has_credentials": True,
+        "notify": None,
+        "status": "pending",
+        "attempts": [],
+        "created_at": "2026-05-19T10:00:00+00:00",
+        "updated_at": "2026-05-19T10:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def test_summarize_trims_and_keeps_last_outcome(tools: Tools):
+    slot = _slot(
+        attempts=[
+            {"ts": "2026-05-19T06:00:00+00:00", "target_date": "2026-05-27",
+             "outcome": "no_slots", "booking_id": None, "error": None},
+            {"ts": "2026-05-20T06:00:00+00:00", "target_date": "2026-05-27",
+             "outcome": "booked", "booking_id": "b-9", "error": None},
+        ]
+    )
+    assert tools._summarize(slot) == {
+        "id": "w-1",
+        "kind": "one_shot",
+        "status": "pending",
+        "target_date": "2026-05-27",
+        "day_of_week": None,
+        "end_date": None,
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "num_slots": 2,
+        "partners": ["p1"],
+        "last_outcome": "booked",
+    }
+
+
+def test_summarize_no_attempts(tools: Tools):
+    assert tools._summarize(_slot())["last_outcome"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k summarize -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute '_summarize'`
+
+- [ ] **Step 3: Add `_summarize` to `Tools`**
+
+Add this method to the `Tools` class in `mcp/src/tee_sniper_mcp/tools.py` (e.g. after `__init__`):
+
+```python
+    @staticmethod
+    def _summarize(slot: dict[str, Any]) -> dict[str, Any]:
+        """Trim a WantedResponse to the fields callers care about."""
+        attempts = slot.get("attempts") or []
+        last_outcome = attempts[-1]["outcome"] if attempts else None
+        return {
+            "id": slot["id"],
+            "kind": slot["kind"],
+            "status": slot["status"],
+            "target_date": slot.get("target_date"),
+            "day_of_week": slot.get("day_of_week"),
+            "end_date": slot.get("end_date"),
+            "start_time": slot["start_time"],
+            "end_time": slot["end_time"],
+            "num_slots": slot["num_slots"],
+            "partners": slot.get("partners", []),
+            "last_outcome": last_outcome,
+        }
+```
+
+Also add the `parse_day_of_week` import at the top of `tools.py`:
+
+```python
+from tee_sniper_mcp.dates import (
+    DateParseError,
+    parse_date,
+    parse_day_of_week,
+    parse_time,
+    resolve_window,
+)
+```
+
+(Replace the existing `from tee_sniper_mcp.dates import ...` line with the block above.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k summarize -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add _summarize helper and wanted-tools test scaffold"
+```
+
+---
+
+### Task 3: `create_one_shot_wanted` tool
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Test: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_wanted_tools.py`:
+
+```python
+import json
+
+
+@respx.mock
+async def test_create_one_shot_wanted_ok(tools: Tools):
+    route = respx.post("http://api.test/api/wanted", params={"kind": "one_shot"}).mock(
+        return_value=httpx.Response(201, json=_slot())
+    )
+
+    result = await tools.create_one_shot_wanted(
+        target_date="next wednesday",
+        start_time="3pm",
+        end_time="5pm",
+        num_slots=2,
+        partners=["p1"],
+    )
+
+    assert result == tools._summarize(_slot())
+    body = json.loads(route.calls.last.request.read())
+    assert body["target_date"] == "2026-05-27"  # today=2026-05-19 (Tue) -> next Wed
+    assert body["start_time"] == "15:00"
+    assert body["end_time"] == "17:00"
+    assert body["num_slots"] == 2
+    assert body["partners"] == ["p1"]
+    # credentials auto-encrypted, never plaintext
+    assert "credentials" in body
+    assert body["credentials"] not in ("alice:1234", "")
+    assert "1234" not in body["credentials"]
+
+
+async def test_create_one_shot_wanted_bad_date(tools: Tools):
+    result = await tools.create_one_shot_wanted(
+        target_date="blursday", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "blursday" in result["error"]
+
+
+@respx.mock
+async def test_create_one_shot_wanted_surfaces_422(tools: Tools):
+    respx.post("http://api.test/api/wanted", params={"kind": "one_shot"}).mock(
+        return_value=httpx.Response(422, json={"detail": "end_time must be after start_time"})
+    )
+    result = await tools.create_one_shot_wanted(
+        target_date="tomorrow", start_time="5pm", end_time="3pm"
+    )
+    assert "error" in result and "end_time must be after start_time" in result["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k create_one_shot -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute 'create_one_shot_wanted'`
+
+- [ ] **Step 3: Implement the tool**
+
+Add the `encrypt_credentials` import near the top of `tools.py`:
+
+```python
+from tee_sniper_mcp.auth import encrypt_credentials
+```
+
+Add a private credential helper and the tool method to the `Tools` class:
+
+```python
+    def _credentials(self) -> str:
+        return encrypt_credentials(
+            self._config.username,
+            self._config.pin,
+            self._config.shared_secret,
+        )
+
+    async def create_one_shot_wanted(
+        self,
+        target_date: str,
+        start_time: str,
+        end_time: str,
+        num_slots: int = 1,
+        partners: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a one-shot wanted tee-time request."""
+        try:
+            td = parse_date(target_date, today=self._today())
+            start = parse_time(start_time)
+            end = parse_time(end_time)
+        except DateParseError as exc:
+            return {"error": str(exc)}
+
+        body = {
+            "target_date": td.isoformat(),
+            "start_time": start,
+            "end_time": end,
+            "num_slots": num_slots,
+            "partners": partners or [],
+            "credentials": self._credentials(),
+        }
+        try:
+            response = await self._api.post(
+                "/api/wanted", params={"kind": "one_shot"}, json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+```
+
+Note: `ApiClient.post` currently has signature `post(self, path, *, json=None)`. It does **not** accept `params`. Add `params` support — see Step 3b.
+
+- [ ] **Step 3b: Extend `ApiClient.post` to accept `params`**
+
+In `mcp/src/tee_sniper_mcp/api_client.py`, change `post` and `patch` to forward `params`:
+
+```python
+    async def post(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self._request("POST", path, params=params, json=json)
+
+    async def patch(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self._request("PATCH", path, params=params, json=json)
+```
+
+`_request` already accepts and forwards `params`, so no further change is needed there.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k create_one_shot -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run the full mcp suite (regression check on api_client change)**
+
+Run: `cd mcp && uv run pytest`
+Expected: PASS (existing `test_api_client.py` and `test_tools.py` still green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/src/tee_sniper_mcp/api_client.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add create_one_shot_wanted tool"
+```
+
+---
+
+### Task 4: `create_recurring_wanted` tool
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Test: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_wanted_tools.py`:
+
+```python
+def _recurring_slot(**over) -> dict:
+    return _slot(
+        kind="recurring",
+        target_date=None,
+        day_of_week=5,
+        end_date="2026-08-01",
+        **over,
+    )
+
+
+@respx.mock
+async def test_create_recurring_wanted_ok(tools: Tools):
+    route = respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(201, json=_recurring_slot())
+    )
+
+    result = await tools.create_recurring_wanted(
+        day_of_week="saturday",
+        start_time="3pm",
+        end_time="5pm",
+        end_date="2026-08-01",
+    )
+
+    assert result == tools._summarize(_recurring_slot())
+    body = json.loads(route.calls.last.request.read())
+    assert body["day_of_week"] == 5
+    assert body["start_time"] == "15:00"
+    assert body["end_time"] == "17:00"
+    assert body["end_date"] == "2026-08-01"
+    assert "1234" not in body["credentials"]
+
+
+@respx.mock
+async def test_create_recurring_wanted_no_end_date_omits_field(tools: Tools):
+    route = respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(201, json=_recurring_slot(end_date=None))
+    )
+    await tools.create_recurring_wanted(
+        day_of_week="sat", start_time="3pm", end_time="5pm"
+    )
+    body = json.loads(route.calls.last.request.read())
+    assert "end_date" not in body
+
+
+async def test_create_recurring_wanted_bad_day(tools: Tools):
+    result = await tools.create_recurring_wanted(
+        day_of_week="funday", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "funday" in result["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k create_recurring -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute 'create_recurring_wanted'`
+
+- [ ] **Step 3: Implement the tool**
+
+Add to the `Tools` class in `tools.py`:
+
+```python
+    async def create_recurring_wanted(
+        self,
+        day_of_week: str | int,
+        start_time: str,
+        end_time: str,
+        num_slots: int = 1,
+        partners: list[str] | None = None,
+        end_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a recurring wanted tee-time request (one weekday)."""
+        try:
+            dow = parse_day_of_week(day_of_week)
+            start = parse_time(start_time)
+            end = parse_time(end_time)
+            ed = (
+                parse_date(end_date, today=self._today()).isoformat()
+                if end_date
+                else None
+            )
+        except DateParseError as exc:
+            return {"error": str(exc)}
+
+        body: dict[str, Any] = {
+            "day_of_week": dow,
+            "start_time": start,
+            "end_time": end,
+            "num_slots": num_slots,
+            "partners": partners or [],
+            "credentials": self._credentials(),
+        }
+        if ed is not None:
+            body["end_date"] = ed
+        try:
+            response = await self._api.post(
+                "/api/wanted", params={"kind": "recurring"}, json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k create_recurring -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add create_recurring_wanted tool"
+```
+
+---
+
+### Task 5: `list_wanted` and `get_wanted` tools
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Test: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_wanted_tools.py`:
+
+```python
+_VALID_STATUSES = {"pending", "booked", "expired", "disabled"}
+
+
+@respx.mock
+async def test_list_wanted_no_filter(tools: Tools):
+    route = respx.get("http://api.test/api/wanted").mock(
+        return_value=httpx.Response(200, json=[_slot(), _recurring_slot()])
+    )
+    result = await tools.list_wanted()
+    assert result == {
+        "wanted": [tools._summarize(_slot()), tools._summarize(_recurring_slot())]
+    }
+    assert "status" not in route.calls.last.request.url.params
+
+
+@respx.mock
+async def test_list_wanted_with_status_filter(tools: Tools):
+    route = respx.get("http://api.test/api/wanted", params={"status": "booked"}).mock(
+        return_value=httpx.Response(200, json=[_slot(status="booked")])
+    )
+    result = await tools.list_wanted(status="booked")
+    assert result["wanted"][0]["status"] == "booked"
+    assert route.calls.last.request.url.params["status"] == "booked"
+
+
+async def test_list_wanted_rejects_bad_status(tools: Tools):
+    result = await tools.list_wanted(status="nope")
+    assert "error" in result and "nope" in result["error"]
+
+
+@respx.mock
+async def test_get_wanted_returns_full_slot(tools: Tools):
+    full = _slot(attempts=[
+        {"ts": "2026-05-19T06:00:00+00:00", "target_date": "2026-05-27",
+         "outcome": "no_slots", "booking_id": None, "error": None},
+    ])
+    respx.get("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=full)
+    )
+    result = await tools.get_wanted(wanted_id="w-1")
+    assert result == full  # full passthrough, not summarized
+
+
+@respx.mock
+async def test_get_wanted_404(tools: Tools):
+    respx.get("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.get_wanted(wanted_id="missing")
+    assert "error" in result and "not found" in result["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k "list_wanted or get_wanted" -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute 'list_wanted'`
+
+- [ ] **Step 3: Implement the tools**
+
+Add to the `Tools` class in `tools.py`:
+
+```python
+    _WANTED_STATUSES = ("pending", "booked", "expired", "disabled")
+
+    async def list_wanted(self, status: str | None = None) -> dict[str, Any]:
+        """List wanted tee-time requests, optionally filtered by status."""
+        params: dict[str, str] | None = None
+        if status is not None:
+            if status not in self._WANTED_STATUSES:
+                return {
+                    "error": (
+                        f"invalid status '{status}'; expected one of "
+                        f"{', '.join(self._WANTED_STATUSES)}"
+                    )
+                }
+            params = {"status": status}
+        try:
+            response = await self._api.get("/api/wanted", params=params)
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return {"wanted": [self._summarize(s) for s in response]}
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
+    async def get_wanted(self, wanted_id: str) -> dict[str, Any]:
+        """Get a single wanted request, including its full attempt history."""
+        try:
+            response = await self._api.get(f"/api/wanted/{wanted_id}")
+        except ApiError as exc:
+            return {"error": str(exc)}
+        if not isinstance(response, dict):
+            return {"error": f"unexpected API response: {response!r}"}
+        return response
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k "list_wanted or get_wanted" -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add list_wanted and get_wanted tools"
+```
+
+---
+
+### Task 6: `update_wanted` tool
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Test: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_wanted_tools.py`:
+
+```python
+@respx.mock
+async def test_update_wanted_sends_only_provided_fields(tools: Tools):
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(num_slots=3))
+    )
+    result = await tools.update_wanted(wanted_id="w-1", num_slots=3)
+    assert result == tools._summarize(_slot(num_slots=3))
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"num_slots": 3}
+
+
+@respx.mock
+async def test_update_wanted_parses_times(tools: Tools):
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot())
+    )
+    await tools.update_wanted(wanted_id="w-1", start_time="3pm", end_time="5pm")
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"start_time": "15:00", "end_time": "17:00"}
+
+
+async def test_update_wanted_no_fields_is_error(tools: Tools):
+    result = await tools.update_wanted(wanted_id="w-1")
+    assert "error" in result and "no fields" in result["error"].lower()
+
+
+async def test_update_wanted_bad_time(tools: Tools):
+    result = await tools.update_wanted(wanted_id="w-1", start_time="half past noon")
+    assert "error" in result
+
+
+@respx.mock
+async def test_update_wanted_404(tools: Tools):
+    respx.patch("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.update_wanted(wanted_id="missing", num_slots=2)
+    assert "error" in result and "not found" in result["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k update_wanted -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute 'update_wanted'`
+
+- [ ] **Step 3: Implement the tool**
+
+Add to the `Tools` class in `tools.py`:
+
+```python
+    async def update_wanted(
+        self,
+        wanted_id: str,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        num_slots: int | None = None,
+        partners: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Edit mutable fields of a wanted request. Only provided fields change."""
+        body: dict[str, Any] = {}
+        try:
+            if start_time is not None:
+                body["start_time"] = parse_time(start_time)
+            if end_time is not None:
+                body["end_time"] = parse_time(end_time)
+        except DateParseError as exc:
+            return {"error": str(exc)}
+        if num_slots is not None:
+            body["num_slots"] = num_slots
+        if partners is not None:
+            body["partners"] = partners
+
+        if not body:
+            return {"error": "no fields to update"}
+
+        try:
+            response = await self._api.patch(
+                f"/api/wanted/{wanted_id}", json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k update_wanted -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add update_wanted tool"
+```
+
+---
+
+### Task 7: `set_wanted_enabled` and `delete_wanted` tools
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/tools.py`
+- Test: `mcp/tests/test_wanted_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `mcp/tests/test_wanted_tools.py`:
+
+```python
+@respx.mock
+async def test_set_wanted_enabled_false_sends_disabled_true(tools: Tools):
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(status="disabled"))
+    )
+    result = await tools.set_wanted_enabled(wanted_id="w-1", enabled=False)
+    assert result == tools._summarize(_slot(status="disabled"))
+    assert json.loads(route.calls.last.request.read()) == {"disabled": True}
+
+
+@respx.mock
+async def test_set_wanted_enabled_true_sends_disabled_false(tools: Tools):
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(status="pending"))
+    )
+    await tools.set_wanted_enabled(wanted_id="w-1", enabled=True)
+    assert json.loads(route.calls.last.request.read()) == {"disabled": False}
+
+
+@respx.mock
+async def test_delete_wanted_ok(tools: Tools):
+    respx.delete("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(204)
+    )
+    result = await tools.delete_wanted(wanted_id="w-1")
+    assert result == {"deleted": True, "id": "w-1"}
+
+
+@respx.mock
+async def test_delete_wanted_404(tools: Tools):
+    respx.delete("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.delete_wanted(wanted_id="missing")
+    assert "error" in result and "not found" in result["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k "set_wanted_enabled or delete_wanted" -v`
+Expected: FAIL — `AttributeError: 'Tools' object has no attribute 'set_wanted_enabled'`
+
+- [ ] **Step 3: Implement the tools**
+
+`ApiClient` has no `delete` method yet — add one. In `mcp/src/tee_sniper_mcp/api_client.py`, add alongside `get`/`post`/`patch`:
+
+```python
+    async def delete(self, path: str) -> Any:
+        return await self._request("DELETE", path)
+```
+
+Add to the `Tools` class in `tools.py`:
+
+```python
+    async def set_wanted_enabled(
+        self, wanted_id: str, enabled: bool
+    ) -> dict[str, Any]:
+        """Pause (enabled=False) or resume (enabled=True) a wanted request."""
+        try:
+            response = await self._api.patch(
+                f"/api/wanted/{wanted_id}", json={"disabled": not enabled}
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
+    async def delete_wanted(self, wanted_id: str) -> dict[str, Any]:
+        """Delete a wanted request."""
+        try:
+            await self._api.delete(f"/api/wanted/{wanted_id}")
+        except ApiError as exc:
+            return {"error": str(exc)}
+        return {"deleted": True, "id": wanted_id}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mcp && uv run pytest tests/test_wanted_tools.py -k "set_wanted_enabled or delete_wanted" -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/tools.py mcp/src/tee_sniper_mcp/api_client.py mcp/tests/test_wanted_tools.py
+git commit -m "feat(mcp): add set_wanted_enabled and delete_wanted tools"
+```
+
+---
+
+### Task 8: Register the 7 tools in server.py + update smoke test
+
+**Files:**
+- Modify: `mcp/src/tee_sniper_mcp/server.py`
+- Test: `mcp/tests/test_tools.py`
+
+- [ ] **Step 1: Update the failing smoke test**
+
+In `mcp/tests/test_tools.py`, replace the body of `test_server_registers_all_four_tools` so it asserts the full set (rename the function for clarity):
+
+```python
+async def test_server_registers_all_tools() -> None:
+    from tee_sniper_mcp.server import build_server
+
+    cfg = Config(
+        api_base_url="http://api.test",
+        username="u",
+        pin="p",
+        shared_secret="s",
+        time_bands_override=None,
+    )
+
+    async with build_server(config=cfg) as mcp:
+        registered = await mcp.list_tools()
+
+    names = {t.name for t in registered}
+    assert names == {
+        "find_tee_times",
+        "book_tee_time",
+        "list_partners",
+        "add_partners",
+        "create_one_shot_wanted",
+        "create_recurring_wanted",
+        "list_wanted",
+        "get_wanted",
+        "update_wanted",
+        "set_wanted_enabled",
+        "delete_wanted",
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp && uv run pytest tests/test_tools.py -k registers_all_tools -v`
+Expected: FAIL — assertion error, only the original 4 names registered.
+
+- [ ] **Step 3: Register the new tools and add descriptions**
+
+In `mcp/src/tee_sniper_mcp/server.py`, inside `build_server` after the existing four `mcp.tool(...)` lines, add:
+
+```python
+        mcp.tool(name="create_one_shot_wanted", description=_CREATE_ONE_SHOT_DESCRIPTION)(
+            tools.create_one_shot_wanted
+        )
+        mcp.tool(name="create_recurring_wanted", description=_CREATE_RECURRING_DESCRIPTION)(
+            tools.create_recurring_wanted
+        )
+        mcp.tool(name="list_wanted", description=_LIST_WANTED_DESCRIPTION)(tools.list_wanted)
+        mcp.tool(name="get_wanted", description=_GET_WANTED_DESCRIPTION)(tools.get_wanted)
+        mcp.tool(name="update_wanted", description=_UPDATE_WANTED_DESCRIPTION)(tools.update_wanted)
+        mcp.tool(name="set_wanted_enabled", description=_SET_WANTED_ENABLED_DESCRIPTION)(
+            tools.set_wanted_enabled
+        )
+        mcp.tool(name="delete_wanted", description=_DELETE_WANTED_DESCRIPTION)(tools.delete_wanted)
+```
+
+Add these description constants alongside the existing `_*_DESCRIPTION` strings:
+
+```python
+_CREATE_ONE_SHOT_DESCRIPTION = """Create a one-shot wanted tee-time request: the worker auto-books a slot for a single target_date when it becomes available.
+
+target_date: 'next saturday', 'in 8 days', 'tomorrow', or ISO 'YYYY-MM-DD'.
+start_time/end_time: e.g. '15:00' or '3pm' (acceptable booking window).
+num_slots: 1-4 (default 1). partners: optional list of partner ids.
+Credentials are taken from server config automatically."""
+
+_CREATE_RECURRING_DESCRIPTION = """Create a recurring wanted tee-time request: the worker auto-books that weekday each time it enters the booking window.
+
+day_of_week: weekday name ('saturday'/'sat') or int 0-6 where 0=Monday … 6=Sunday.
+start_time/end_time: e.g. '15:00' or '3pm'. end_date: optional last date ('YYYY-MM-DD' or natural language); omit for open-ended.
+num_slots: 1-4 (default 1). partners: optional list of partner ids.
+Credentials are taken from server config automatically."""
+
+_LIST_WANTED_DESCRIPTION = """List wanted tee-time requests (trimmed summaries). Optional status filter: pending, booked, expired, disabled."""
+
+_GET_WANTED_DESCRIPTION = """Get one wanted request by id, including its full attempt history."""
+
+_UPDATE_WANTED_DESCRIPTION = """Edit a wanted request. Provide only the fields to change: start_time, end_time, num_slots, partners. Cannot change kind/date/day_of_week (recreate instead) or pause it (use set_wanted_enabled)."""
+
+_SET_WANTED_ENABLED_DESCRIPTION = """Pause or resume a wanted request. enabled=false disables it; enabled=true restores a disabled request to pending."""
+
+_DELETE_WANTED_DESCRIPTION = """Permanently delete a wanted request by id."""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp && uv run pytest tests/test_tools.py -k registers_all_tools -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full mcp suite**
+
+Run: `cd mcp && uv run pytest`
+Expected: PASS (all tests, all files)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp/src/tee_sniper_mcp/server.py mcp/tests/test_tools.py
+git commit -m "feat(mcp): register 7 wanted-tee-time tools"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `mcp/README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update `mcp/README.md`**
+
+Add a "Wanted tee-times" subsection to the tool reference documenting all 7 tools, their arguments, and the **0 = Monday … 6 = Sunday** day-of-week convention. Match the format/voice of the existing tool reference entries for the original four tools (read the surrounding section first and mirror its structure — argument lists, examples, time-of-day notes).
+
+- [ ] **Step 2: Update `CLAUDE.md`**
+
+In the "MCP Server (Local)" section, update the sentence "proxies four tools (`find_tee_times`, `book_tee_time`, `list_partners`, `add_partners`)" to also mention the 7 wanted tools, and add a one-line pointer to the spec `docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md` and this plan in the "MCP Plan History" subsection.
+
+- [ ] **Step 3: Verify docs build/render (sanity)**
+
+Run: `cd mcp && uv run pytest`
+Expected: PASS (no test impact; this step confirms nothing was broken by edits in adjacent files).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mcp/README.md CLAUDE.md
+git commit -m "docs(mcp): document wanted-tee-time tools"
+```
+
+---
+
+### Final verification
+
+- [ ] Run full suite: `cd mcp && uv run pytest` — all green.
+- [ ] Run API suite unaffected (sanity, no api/ changes expected): no action needed unless api/ was touched.
+- [ ] Controller (not subagents) pushes the branch and opens a single combined PR titled "Add wanted tee-time MCP tools", linking the spec and plan.
+
+## Notes for the implementer
+
+- **Never plaintext credentials.** The create tools must call `self._credentials()` (which calls `encrypt_credentials`). Tests assert the PIN string is absent from the request body — keep it that way.
+- **`ApiClient` signature changes** in Tasks 3 and 7 (`params=` on post/patch, new `delete`) are load-bearing for later tasks. Run the full suite after Task 3 to catch regressions early.
+- **Out of scope (do not add):** SMS `notify`, per-call credential override, editing kind/target_date/day_of_week. These are deliberately excluded per the spec.
+- **Day-of-week is 0=Monday.** Verified against `api/app/services/scheduling.py`. Do not "fix" it to 0=Sunday.

--- a/docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md
@@ -1,0 +1,173 @@
+# Wanted Tee-Time MCP Tools — Design
+
+Date: 2026-05-19
+
+## Goal
+
+Expose the persisted auto-booking ("wanted tee-times") feature through the
+local MCP server so an LLM/user can create, inspect, edit, pause, and delete
+wanted-slot requests without leaving Claude Desktop / MetaMCP.
+
+Background:
+
+- Wanted API spec: `docs/superpowers/specs/2026-05-16-wanted-tee-times-design.md`
+- Wanted router: `api/app/routers/wanted.py` (`/api/wanted`, session-authed)
+- MCP server: `mcp/src/tee_sniper_mcp/` (stdio FastMCP, REST client)
+
+## Scope & Architecture
+
+Add **7 tools** to the existing `Tools` class
+(`mcp/src/tee_sniper_mcp/tools.py`), registered in `server.py`. Each tool
+proxies a `/api/wanted` endpoint via the existing `ApiClient` (lazy login +
+in-memory token cache + single 401 retry already implemented in
+`api_client.py` / `auth.py`).
+
+No new infrastructure. Same conventions as the existing 4 tools:
+
+- Return a JSON-friendly `dict` on success.
+- On any failure return `{"error": "..."}` (optionally with extra keys) —
+  **never raise** out of a tool method.
+- Local parse failures short-circuit before any HTTP call.
+
+Tools:
+
+1. `create_one_shot_wanted`
+2. `create_recurring_wanted`
+3. `list_wanted`
+4. `get_wanted`
+5. `update_wanted`
+6. `set_wanted_enabled`
+7. `delete_wanted`
+
+Existing 4 tools (`find_tee_times`, `book_tee_time`, `list_partners`,
+`add_partners`) are unchanged.
+
+## Tool Signatures
+
+### `create_one_shot_wanted(target_date, start_time, end_time, num_slots=1, partners=None)`
+
+- `POST /api/wanted?kind=one_shot`.
+- `target_date`: natural-language (`'next saturday'`, `'in 3 days'`,
+  `'tomorrow'`) or ISO `YYYY-MM-DD`, via existing `parse_date`.
+- `start_time` / `end_time`: via `parse_time` → canonical `HH:MM`.
+- `partners`: optional list of partner ids (≤3; API enforces).
+- `credentials`: **auto-encrypted from config** using `encrypt_credentials`
+  (same AES-256-GCM scheme as login) from `TSA_USERNAME` / `TSA_PIN` /
+  `TSA_SHARED_SECRET`. Never a tool argument; the LLM/user never sees it.
+- Returns the created slot summary (see Response Shaping).
+
+### `create_recurring_wanted(day_of_week, start_time, end_time, num_slots=1, partners=None, end_date=None)`
+
+- `POST /api/wanted?kind=recurring`.
+- `day_of_week`: accepts `"saturday"` / `"sat"` / `"6"` / `6` →
+  normalized to int `0–6`. Convention: **0 = Monday … 6 = Sunday**
+  (matches `WantedSlot.day_of_week`, `ge=0, le=6`).
+- `end_date`: optional, natural-language or ISO; omit for open-ended.
+- `start_time` / `end_time` / `partners` / credentials: as above.
+
+### `list_wanted(status=None)`
+
+- `GET /api/wanted`, optional `status` filter ∈
+  `pending` | `booked` | `expired` | `disabled`.
+- Invalid `status` value → `{"error": ...}` before the HTTP call.
+- Returns `{"wanted": [<summary>, ...]}` (trimmed; see Response Shaping).
+
+### `get_wanted(wanted_id)`
+
+- `GET /api/wanted/{id}`.
+- Returns the full slot including `attempts` history.
+- 404 → `{"error": "wanted slot not found"}`.
+
+### `update_wanted(wanted_id, start_time=None, end_time=None, num_slots=None, partners=None)`
+
+- `PATCH /api/wanted/{id}`. Only fields explicitly provided are sent
+  (omitted args are not included in the patch body).
+- `start_time` / `end_time` parsed via `parse_time` when provided.
+- **Not** exposed: `notify` (deliberately out of scope), `credentials`
+  (re-deriving from config would be a no-op), and the immutable
+  `kind` / `target_date` / `day_of_week`.
+- 404 / 422 → `{"error": ...}` (API 422 detail surfaced verbatim).
+
+### `set_wanted_enabled(wanted_id, enabled)`
+
+- `PATCH /api/wanted/{id}` with body `{"disabled": not enabled}`.
+- `enabled=False` → API sets status `disabled`; `enabled=True` →
+  API restores a disabled slot to `pending`.
+- Returns the updated slot summary.
+
+### `delete_wanted(wanted_id)`
+
+- `DELETE /api/wanted/{id}`. 204 → `{"deleted": true, "id": wanted_id}`.
+- 404 → `{"error": "wanted slot not found"}`.
+
+## Day-of-Week Normalization
+
+A helper (placed in `dates.py` alongside the existing parsers) maps
+day input → `int 0–6`:
+
+- Full names (`"monday"`), 3-letter abbreviations (`"mon"`),
+  case-insensitive.
+- Numeric strings (`"0"`) and ints (`0`) passed through with range check.
+- Anything else → `DateParseError`.
+
+Convention **0 = Monday … 6 = Sunday**. During implementation, verify this
+against the worker's `api/app/services/scheduling.py` `is_due` logic so the
+tool description and spec stay accurate; if the worker uses a different
+convention, the worker is authoritative — adjust this doc and the helper.
+
+## Response Shaping
+
+- **List**: trimmed summary per slot — `id`, `kind`, `status`,
+  `target_date` or `day_of_week`+`end_date`, `start_time`, `end_time`,
+  `num_slots`, `partners`, and the most recent attempt outcome (if any).
+- **Get**: pass through the full `WantedResponse` (includes
+  `has_credentials`, full `attempts`). `credentials` is already stripped
+  server-side (`WantedResponse.from_slot`).
+- **Create / update / set_enabled**: return the same trimmed summary as
+  list, so the caller can confirm what was stored.
+
+## Error Handling
+
+Mirrors the existing tools:
+
+- Local: `DateParseError` (bad date/time/day-of-week), invalid `status`,
+  out-of-range numeric day → `{"error": str}` **before** any HTTP call.
+- Remote: `ApiError` (401-after-retry, 404, 422, 5xx) → `{"error": str}`.
+  The `ApiClient` already extracts the API's `detail` string.
+- Validation the API already enforces (window ordering, `num_slots` 1–4,
+  ≤3 partners, kind/date invariants) is **not** duplicated in the MCP —
+  the 422 detail is surfaced back so the LLM can correct itself. Local
+  pre-checks are limited to parse failures that save an obvious round-trip.
+
+## Testing
+
+Follow `mcp/tests/` patterns:
+
+- Unit test per tool with a stubbed `ApiClient` — success path and at
+  least one error path (parse error and/or API error) each.
+- Day-of-week + date normalization unit tests (names, abbreviations,
+  ints, numeric strings, invalid input).
+- `credentials` auto-encryption asserted on the create tools (encrypted
+  blob present in the request body, not a plaintext field).
+- Update `test_tools.py` `list_tools()` smoke test to assert all 7 new
+  tools register (11 total).
+
+Run: `cd mcp && uv run pytest`.
+
+## Documentation
+
+Update `mcp/README.md` and the CLAUDE.md MCP section with the 7 new tools
+(reference + the 0=Monday day-of-week convention).
+
+## Out of Scope
+
+- SMS `notify` on wanted slots via MCP (slots created via MCP never notify).
+- Per-call credential override (always the configured account).
+- Editing `kind` / `target_date` / `day_of_week` of an existing slot
+  (immutable in the API; recreate instead).
+
+## Workflow Note
+
+Implementation will be done on a new git worktree taken from `main`
+(per the originating request) and shipped as a single combined PR
+(per project preference for multi-phase work).

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -30,6 +30,28 @@ so a typical booking flow performs exactly one login.
 | `list_partners()` | Configured playing partners (id → name). |
 | `add_partners(booking_id, partner_ids, [dry_run])` | Add 1–3 partners to an existing booking. |
 
+### Wanted tee-times
+
+Persisted auto-booking requests. The worker checks each request and books a
+slot when the target date (or next occurrence) enters the 8-day booking window
+and a matching slot is available. Credentials for the booking call are taken
+from the server's own config (`TSA_USERNAME`, `TSA_PIN`, `TSA_SHARED_SECRET`)
+— no credential arguments are needed on these tools.
+
+**Day-of-week convention:** integers 0–6 where **0 = Monday … 6 = Sunday**.
+Weekday names (`'saturday'`, `'sat'`) are also accepted and converted
+automatically.
+
+| Tool | Purpose |
+|---|---|
+| `create_one_shot_wanted(target_date, start_time, end_time, [num_slots], [partners])` | Create a one-shot request that auto-books a single target date when it enters the booking window. `target_date` accepts the same formats as `find_tee_times` (`'next saturday'`, `'in 8 days'`, `'YYYY-MM-DD'`). `start_time`/`end_time` define the acceptable booking window (e.g. `'15:00'` or `'3pm'`). `num_slots` 1–4 (default 1). `partners` is an optional list of partner ids. |
+| `create_recurring_wanted(day_of_week, start_time, end_time, [num_slots], [partners], [end_date])` | Create a recurring request that auto-books the given weekday each time it enters the booking window. `day_of_week` is a weekday name (`'saturday'`/`'sat'`) or int 0–6 (0=Monday … 6=Sunday). `end_date` is an optional last date (`'YYYY-MM-DD'` or natural language); omit for open-ended. |
+| `list_wanted([status])` | List wanted requests (trimmed summaries). Optional `status` filter: `pending`, `booked`, `expired`, `disabled`. |
+| `get_wanted(wanted_id)` | Get one wanted request by id, including its full attempt history. |
+| `update_wanted(wanted_id, [start_time], [end_time], [num_slots], [partners])` | Edit a wanted request. Provide only the fields to change. Cannot change `kind`, `target_date`, or `day_of_week` — recreate instead. Use `set_wanted_enabled` to pause/resume. |
+| `set_wanted_enabled(wanted_id, enabled)` | Pause (`enabled=false`) or resume (`enabled=true`) a wanted request. |
+| `delete_wanted(wanted_id)` | Permanently delete a wanted request. |
+
 ## Time-of-day bands
 
 Defaults: `early_morning` 06–09, `morning` 09–12, `midday` 11–14,

--- a/mcp/src/tee_sniper_mcp/api_client.py
+++ b/mcp/src/tee_sniper_mcp/api_client.py
@@ -48,6 +48,9 @@ class ApiClient:
     ) -> Any:
         return await self._request("PATCH", path, params=params, json=json)
 
+    async def delete(self, path: str) -> Any:
+        return await self._request("DELETE", path)
+
     async def _request(
         self,
         method: str,

--- a/mcp/src/tee_sniper_mcp/api_client.py
+++ b/mcp/src/tee_sniper_mcp/api_client.py
@@ -30,11 +30,23 @@ class ApiClient:
     async def get(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
         return await self._request("GET", path, params=params)
 
-    async def post(self, path: str, *, json: dict[str, Any] | None = None) -> Any:
-        return await self._request("POST", path, json=json)
+    async def post(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self._request("POST", path, params=params, json=json)
 
-    async def patch(self, path: str, *, json: dict[str, Any] | None = None) -> Any:
-        return await self._request("PATCH", path, json=json)
+    async def patch(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self._request("PATCH", path, params=params, json=json)
 
     async def _request(
         self,

--- a/mcp/src/tee_sniper_mcp/dates.py
+++ b/mcp/src/tee_sniper_mcp/dates.py
@@ -73,6 +73,33 @@ def parse_date(value: str, *, today: dt.date | None = None) -> dt.date:
     return parsed.date()
 
 
+_WEEKDAY_ABBR = {name[:3]: idx for name, idx in _WEEKDAYS.items()}
+
+
+def parse_day_of_week(value: str | int) -> int:
+    """Normalize a weekday to int 0-6 (0=Monday … 6=Sunday)."""
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise DateParseError(f"invalid day_of_week: {value!r}")
+    if isinstance(value, int):
+        if 0 <= value <= 6:
+            return value
+        raise DateParseError(f"day_of_week out of range (0-6): {value}")
+
+    s = value.strip().lower()
+    if not s:
+        raise DateParseError("empty day_of_week")
+    if s in _WEEKDAYS:
+        return _WEEKDAYS[s]
+    if s in _WEEKDAY_ABBR:
+        return _WEEKDAY_ABBR[s]
+    if s.lstrip("-").isdigit():
+        n = int(s)
+        if 0 <= n <= 6:
+            return n
+        raise DateParseError(f"day_of_week out of range (0-6): {s}")
+    raise DateParseError(f"unknown day_of_week '{value}'")
+
+
 def parse_time(value: str) -> str:
     """Parse a time string into 'HH:MM' 24-hour format."""
     s = value.strip()

--- a/mcp/src/tee_sniper_mcp/server.py
+++ b/mcp/src/tee_sniper_mcp/server.py
@@ -35,6 +35,20 @@ async def build_server(*, config: Config) -> AsyncIterator[FastMCP]:
         mcp.tool(name="list_partners", description=_LIST_PARTNERS_DESCRIPTION)(tools.list_partners)
         mcp.tool(name="add_partners", description=_ADD_PARTNERS_DESCRIPTION)(tools.add_partners)
 
+        mcp.tool(name="create_one_shot_wanted", description=_CREATE_ONE_SHOT_DESCRIPTION)(
+            tools.create_one_shot_wanted
+        )
+        mcp.tool(name="create_recurring_wanted", description=_CREATE_RECURRING_DESCRIPTION)(
+            tools.create_recurring_wanted
+        )
+        mcp.tool(name="list_wanted", description=_LIST_WANTED_DESCRIPTION)(tools.list_wanted)
+        mcp.tool(name="get_wanted", description=_GET_WANTED_DESCRIPTION)(tools.get_wanted)
+        mcp.tool(name="update_wanted", description=_UPDATE_WANTED_DESCRIPTION)(tools.update_wanted)
+        mcp.tool(name="set_wanted_enabled", description=_SET_WANTED_ENABLED_DESCRIPTION)(
+            tools.set_wanted_enabled
+        )
+        mcp.tool(name="delete_wanted", description=_DELETE_WANTED_DESCRIPTION)(tools.delete_wanted)
+
         yield mcp
 
 
@@ -55,6 +69,30 @@ _BOOK_DESCRIPTION = """Book a tee time. num_slots is 1–4 (default 1). Set dry_
 _LIST_PARTNERS_DESCRIPTION = """List configured playing partners (id and name) you can add to a booking."""
 
 _ADD_PARTNERS_DESCRIPTION = """Add 1–3 playing partners (by id from list_partners) to an existing booking."""
+
+_CREATE_ONE_SHOT_DESCRIPTION = """Create a one-shot wanted tee-time request: the worker auto-books a slot for a single target_date when it becomes available.
+
+target_date: 'next saturday', 'in 8 days', 'tomorrow', or ISO 'YYYY-MM-DD'.
+start_time/end_time: e.g. '15:00' or '3pm' (acceptable booking window).
+num_slots: 1-4 (default 1). partners: optional list of partner ids.
+Credentials are taken from server config automatically."""
+
+_CREATE_RECURRING_DESCRIPTION = """Create a recurring wanted tee-time request: the worker auto-books that weekday each time it enters the booking window.
+
+day_of_week: weekday name ('saturday'/'sat') or int 0-6 where 0=Monday … 6=Sunday.
+start_time/end_time: e.g. '15:00' or '3pm'. end_date: optional last date ('YYYY-MM-DD' or natural language); omit for open-ended.
+num_slots: 1-4 (default 1). partners: optional list of partner ids.
+Credentials are taken from server config automatically."""
+
+_LIST_WANTED_DESCRIPTION = """List wanted tee-time requests (trimmed summaries). Optional status filter: pending, booked, expired, disabled."""
+
+_GET_WANTED_DESCRIPTION = """Get one wanted request by id, including its full attempt history."""
+
+_UPDATE_WANTED_DESCRIPTION = """Edit a wanted request. Provide only the fields to change: start_time, end_time, num_slots, partners. Cannot change kind/date/day_of_week (recreate instead) or pause it (use set_wanted_enabled)."""
+
+_SET_WANTED_ENABLED_DESCRIPTION = """Pause or resume a wanted request. enabled=false disables it; enabled=true restores a disabled request to pending."""
+
+_DELETE_WANTED_DESCRIPTION = """Permanently delete a wanted request by id."""
 
 
 async def _async_main() -> int:

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from typing import Any
 
 from tee_sniper_mcp.api_client import ApiClient, ApiError
+from tee_sniper_mcp.auth import encrypt_credentials
 from tee_sniper_mcp.config import Config
 from tee_sniper_mcp.dates import (
     DateParseError,
@@ -21,7 +22,7 @@ from tee_sniper_mcp.dates import (
 
 
 class Tools:
-    """Bundle of the four MCP tool implementations."""
+    """Bundle of MCP tool implementations."""
 
     def __init__(
         self,
@@ -51,6 +52,49 @@ class Tools:
             "partners": slot.get("partners", []),
             "last_outcome": last_outcome,
         }
+
+    def _credentials(self) -> str:
+        return encrypt_credentials(
+            self._config.username,
+            self._config.pin,
+            self._config.shared_secret,
+        )
+
+    async def create_one_shot_wanted(
+        self,
+        target_date: str,
+        start_time: str,
+        end_time: str,
+        num_slots: int = 1,
+        partners: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a one-shot wanted tee-time request."""
+        try:
+            td = parse_date(target_date, today=self._today())
+            start = parse_time(start_time)
+            end = parse_time(end_time)
+        except DateParseError as exc:
+            return {"error": str(exc)}
+
+        body = {
+            "target_date": td.isoformat(),
+            "start_time": start,
+            "end_time": end,
+            "num_slots": num_slots,
+            "partners": partners or [],
+            "credentials": self._credentials(),
+        }
+        try:
+            response = await self._api.post(
+                "/api/wanted", params={"kind": "one_shot"}, json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
 
     async def find_tee_times(
         self,

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -174,6 +174,42 @@ class Tools:
             return {"error": f"unexpected API response: {response!r}"}
         return response
 
+    async def update_wanted(
+        self,
+        wanted_id: str,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        num_slots: int | None = None,
+        partners: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Edit mutable fields of a wanted request. Only provided fields change."""
+        body: dict[str, Any] = {}
+        try:
+            if start_time is not None:
+                body["start_time"] = parse_time(start_time)
+            if end_time is not None:
+                body["end_time"] = parse_time(end_time)
+        except DateParseError as exc:
+            return {"error": str(exc)}
+        if num_slots is not None:
+            body["num_slots"] = num_slots
+        if partners is not None:
+            body["partners"] = partners
+
+        if not body:
+            return {"error": "no fields to update"}
+
+        try:
+            response = await self._api.patch(
+                f"/api/wanted/{wanted_id}", json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
     async def find_tee_times(
         self,
         date: str,

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -210,6 +210,29 @@ class Tools:
         except (KeyError, TypeError) as exc:
             return {"error": f"unexpected API response: {exc}"}
 
+    async def set_wanted_enabled(
+        self, wanted_id: str, enabled: bool
+    ) -> dict[str, Any]:
+        """Pause (enabled=False) or resume (enabled=True) a wanted request."""
+        try:
+            response = await self._api.patch(
+                f"/api/wanted/{wanted_id}", json={"disabled": not enabled}
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
+    async def delete_wanted(self, wanted_id: str) -> dict[str, Any]:
+        """Delete a wanted request."""
+        try:
+            await self._api.delete(f"/api/wanted/{wanted_id}")
+        except ApiError as exc:
+            return {"error": str(exc)}
+        return {"deleted": True, "id": wanted_id}
+
     async def find_tee_times(
         self,
         date: str,

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -141,6 +141,39 @@ class Tools:
         except (KeyError, TypeError) as exc:
             return {"error": f"unexpected API response: {exc}"}
 
+    _WANTED_STATUSES = ("pending", "booked", "expired", "disabled")
+
+    async def list_wanted(self, status: str | None = None) -> dict[str, Any]:
+        """List wanted tee-time requests, optionally filtered by status."""
+        params: dict[str, str] | None = None
+        if status is not None:
+            if status not in self._WANTED_STATUSES:
+                return {
+                    "error": (
+                        f"invalid status '{status}'; expected one of "
+                        f"{', '.join(self._WANTED_STATUSES)}"
+                    )
+                }
+            params = {"status": status}
+        try:
+            response = await self._api.get("/api/wanted", params=params)
+        except ApiError as exc:
+            return {"error": str(exc)}
+        try:
+            return {"wanted": [self._summarize(s) for s in response]}
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
+    async def get_wanted(self, wanted_id: str) -> dict[str, Any]:
+        """Get a single wanted request, including its full attempt history."""
+        try:
+            response = await self._api.get(f"/api/wanted/{wanted_id}")
+        except ApiError as exc:
+            return {"error": str(exc)}
+        if not isinstance(response, dict):
+            return {"error": f"unexpected API response: {response!r}"}
+        return response
+
     async def find_tee_times(
         self,
         date: str,

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -12,7 +12,12 @@ from typing import Any
 
 from tee_sniper_mcp.api_client import ApiClient, ApiError
 from tee_sniper_mcp.config import Config
-from tee_sniper_mcp.dates import DateParseError, parse_date, parse_time, resolve_window
+from tee_sniper_mcp.dates import (
+    DateParseError,
+    parse_date,
+    parse_time,
+    resolve_window,
+)
 
 
 class Tools:
@@ -27,6 +32,25 @@ class Tools:
         self._config = config
         self._api = api
         self._today = today
+
+    @staticmethod
+    def _summarize(slot: dict[str, Any]) -> dict[str, Any]:
+        """Trim a WantedResponse to the fields callers care about."""
+        attempts = slot.get("attempts") or []
+        last_outcome = attempts[-1]["outcome"] if attempts else None
+        return {
+            "id": slot["id"],
+            "kind": slot["kind"],
+            "status": slot["status"],
+            "target_date": slot.get("target_date"),
+            "day_of_week": slot.get("day_of_week"),
+            "end_date": slot.get("end_date"),
+            "start_time": slot["start_time"],
+            "end_time": slot["end_time"],
+            "num_slots": slot["num_slots"],
+            "partners": slot.get("partners", []),
+            "last_outcome": last_outcome,
+        }
 
     async def find_tee_times(
         self,

--- a/mcp/src/tee_sniper_mcp/tools.py
+++ b/mcp/src/tee_sniper_mcp/tools.py
@@ -16,6 +16,7 @@ from tee_sniper_mcp.config import Config
 from tee_sniper_mcp.dates import (
     DateParseError,
     parse_date,
+    parse_day_of_week,
     parse_time,
     resolve_window,
 )
@@ -87,6 +88,50 @@ class Tools:
         try:
             response = await self._api.post(
                 "/api/wanted", params={"kind": "one_shot"}, json=body
+            )
+        except ApiError as exc:
+            return {"error": str(exc)}
+
+        try:
+            return self._summarize(response)
+        except (KeyError, TypeError) as exc:
+            return {"error": f"unexpected API response: {exc}"}
+
+    async def create_recurring_wanted(
+        self,
+        day_of_week: str | int,
+        start_time: str,
+        end_time: str,
+        num_slots: int = 1,
+        partners: list[str] | None = None,
+        end_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a recurring wanted tee-time request (one weekday)."""
+        try:
+            dow = parse_day_of_week(day_of_week)
+            start = parse_time(start_time)
+            end = parse_time(end_time)
+            ed = (
+                parse_date(end_date, today=self._today()).isoformat()
+                if end_date
+                else None
+            )
+        except DateParseError as exc:
+            return {"error": str(exc)}
+
+        body: dict[str, Any] = {
+            "day_of_week": dow,
+            "start_time": start,
+            "end_time": end,
+            "num_slots": num_slots,
+            "partners": partners or [],
+            "credentials": self._credentials(),
+        }
+        if ed is not None:
+            body["end_date"] = ed
+        try:
+            response = await self._api.post(
+                "/api/wanted", params={"kind": "recurring"}, json=body
             )
         except ApiError as exc:
             return {"error": str(exc)}

--- a/mcp/tests/test_dates.py
+++ b/mcp/tests/test_dates.py
@@ -8,6 +8,7 @@ from tee_sniper_mcp.dates import (
     DateParseError,
     DEFAULT_BANDS,
     parse_date,
+    parse_day_of_week,
     parse_time,
     resolve_band,
     resolve_window,
@@ -98,3 +99,28 @@ def test_resolve_window_band_used_when_no_explicit() -> None:
 
 def test_resolve_window_no_filter() -> None:
     assert resolve_window(start_time=None, end_time=None, time_of_day=None) == (None, None)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("monday", 0),
+        ("Monday", 0),
+        (" MON ", 0),
+        ("sat", 5),
+        ("saturday", 5),
+        ("sunday", 6),
+        ("0", 0),
+        ("6", 6),
+        (0, 0),
+        (6, 6),
+    ],
+)
+def test_parse_day_of_week_ok(value, expected) -> None:
+    assert parse_day_of_week(value) == expected
+
+
+@pytest.mark.parametrize("value", ["funday", "", "7", "-1", 7, -1, "mondayy"])
+def test_parse_day_of_week_rejects_junk(value) -> None:
+    with pytest.raises(DateParseError):
+        parse_day_of_week(value)

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -207,7 +207,7 @@ async def test_add_partners_handles_malformed_api_response(tools: Tools) -> None
     assert "unexpected API response" in result["error"]
 
 
-async def test_server_registers_all_four_tools() -> None:
+async def test_server_registers_all_tools() -> None:
     from tee_sniper_mcp.server import build_server
 
     # Build with stub config (no env mutation needed because we pass it directly).
@@ -223,4 +223,16 @@ async def test_server_registers_all_four_tools() -> None:
         registered = await mcp.list_tools()
 
     names = {t.name for t in registered}
-    assert names == {"find_tee_times", "book_tee_time", "list_partners", "add_partners"}
+    assert names == {
+        "find_tee_times",
+        "book_tee_time",
+        "list_partners",
+        "add_partners",
+        "create_one_shot_wanted",
+        "create_recurring_wanted",
+        "list_wanted",
+        "get_wanted",
+        "update_wanted",
+        "set_wanted_enabled",
+        "delete_wanted",
+    }

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -246,3 +246,43 @@ async def test_get_wanted_404(tools: Tools) -> None:
     )
     result = await tools.get_wanted(wanted_id="missing")
     assert "error" in result and "not found" in result["error"]
+
+
+@respx.mock
+async def test_update_wanted_sends_only_provided_fields(tools: Tools) -> None:
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(num_slots=3))
+    )
+    result = await tools.update_wanted(wanted_id="w-1", num_slots=3)
+    assert result == tools._summarize(_slot(num_slots=3))
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"num_slots": 3}
+
+
+@respx.mock
+async def test_update_wanted_parses_times(tools: Tools) -> None:
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot())
+    )
+    await tools.update_wanted(wanted_id="w-1", start_time="3pm", end_time="5pm")
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"start_time": "15:00", "end_time": "17:00"}
+
+
+async def test_update_wanted_no_fields_is_error(tools: Tools) -> None:
+    result = await tools.update_wanted(wanted_id="w-1")
+    assert "error" in result and "no fields" in result["error"].lower()
+
+
+async def test_update_wanted_bad_time(tools: Tools) -> None:
+    result = await tools.update_wanted(wanted_id="w-1", start_time="half past noon")
+    assert "error" in result
+
+
+@respx.mock
+async def test_update_wanted_404(tools: Tools) -> None:
+    respx.patch("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.update_wanted(wanted_id="missing", num_slots=2)
+    assert "error" in result and "not found" in result["error"]

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -196,3 +196,53 @@ async def test_create_recurring_wanted_bad_day(tools: Tools) -> None:
         day_of_week="funday", start_time="3pm", end_time="5pm"
     )
     assert "error" in result and "funday" in result["error"]
+
+
+@respx.mock
+async def test_list_wanted_no_filter(tools: Tools) -> None:
+    route = respx.get("http://api.test/api/wanted").mock(
+        return_value=httpx.Response(200, json=[_slot(), _recurring_slot()])
+    )
+    result = await tools.list_wanted()
+    assert result == {
+        "wanted": [tools._summarize(_slot()), tools._summarize(_recurring_slot())]
+    }
+    assert "status" not in route.calls.last.request.url.params
+
+
+@respx.mock
+async def test_list_wanted_with_status_filter(tools: Tools) -> None:
+    route = respx.get("http://api.test/api/wanted", params={"status": "booked"}).mock(
+        return_value=httpx.Response(200, json=[_slot(status="booked")])
+    )
+    result = await tools.list_wanted(status="booked")
+    assert result["wanted"][0]["status"] == "booked"
+    assert route.calls.last.request.url.params["status"] == "booked"
+
+
+async def test_list_wanted_rejects_bad_status(tools: Tools) -> None:
+    result = await tools.list_wanted(status="nope")
+    assert "error" in result and "nope" in result["error"]
+    assert "pending" in result["error"]
+
+
+@respx.mock
+async def test_get_wanted_returns_full_slot(tools: Tools) -> None:
+    full = _slot(attempts=[
+        {"ts": "2026-05-19T06:00:00+00:00", "target_date": "2026-05-27",
+         "outcome": "no_slots", "booking_id": None, "error": None},
+    ])
+    respx.get("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=full)
+    )
+    result = await tools.get_wanted(wanted_id="w-1")
+    assert result == full  # full passthrough, not summarized
+
+
+@respx.mock
+async def test_get_wanted_404(tools: Tools) -> None:
+    respx.get("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.get_wanted(wanted_id="missing")
+    assert "error" in result and "not found" in result["error"]

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -1,0 +1,87 @@
+"""Tests for the wanted-tee-time MCP tools."""
+
+import datetime as dt
+
+import httpx
+import pytest
+import respx
+
+from tee_sniper_mcp.api_client import ApiClient
+from tee_sniper_mcp.auth import AuthManager
+from tee_sniper_mcp.config import Config
+from tee_sniper_mcp.tools import Tools
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        api_base_url="http://api.test",
+        username="alice",
+        pin="1234",
+        shared_secret="s3cret",
+        time_bands_override=None,
+    )
+
+
+def _login_response() -> httpx.Response:
+    expires = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=30)).isoformat()
+    return httpx.Response(200, json={"access_token": "tok-1", "expires_at": expires})
+
+
+@pytest.fixture
+async def tools(config: Config):
+    with respx.MockRouter(assert_all_called=False) as router:
+        router.post("http://api.test/api/login").mock(return_value=_login_response())
+        async with httpx.AsyncClient() as http:
+            api = ApiClient(config, AuthManager(config, http), http)
+            yield Tools(config=config, api=api, today=lambda: dt.date(2026, 5, 19))
+
+
+def _slot(**over) -> dict:
+    base = {
+        "id": "w-1",
+        "kind": "one_shot",
+        "target_date": "2026-05-27",
+        "day_of_week": None,
+        "end_date": None,
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "num_slots": 2,
+        "partners": ["p1"],
+        "has_credentials": True,
+        "notify": None,
+        "status": "pending",
+        "attempts": [],
+        "created_at": "2026-05-19T10:00:00+00:00",
+        "updated_at": "2026-05-19T10:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def test_summarize_trims_and_keeps_last_outcome() -> None:
+    slot = _slot(
+        attempts=[
+            {"ts": "2026-05-19T06:00:00+00:00", "target_date": "2026-05-27",
+             "outcome": "no_slots", "booking_id": None, "error": None},
+            {"ts": "2026-05-20T06:00:00+00:00", "target_date": "2026-05-27",
+             "outcome": "booked", "booking_id": "b-9", "error": None},
+        ]
+    )
+    assert Tools._summarize(slot) == {
+        "id": "w-1",
+        "kind": "one_shot",
+        "status": "pending",
+        "target_date": "2026-05-27",
+        "day_of_week": None,
+        "end_date": None,
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "num_slots": 2,
+        "partners": ["p1"],
+        "last_outcome": "booked",
+    }
+
+
+def test_summarize_no_attempts() -> None:
+    assert Tools._summarize(_slot())["last_outcome"] is None

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -131,3 +131,68 @@ async def test_create_one_shot_wanted_surfaces_422(tools: Tools) -> None:
         target_date="tomorrow", start_time="5pm", end_time="3pm"
     )
     assert "error" in result and "end_time must be after start_time" in result["error"]
+
+
+def _recurring_slot(**over) -> dict:
+    defaults = dict(
+        kind="recurring",
+        target_date=None,
+        day_of_week=5,
+        end_date="2026-08-01",
+    )
+    defaults.update(over)
+    return _slot(**defaults)
+
+
+@respx.mock
+async def test_create_recurring_wanted_ok(tools: Tools) -> None:
+    route = respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(201, json=_recurring_slot())
+    )
+
+    result = await tools.create_recurring_wanted(
+        day_of_week="saturday",
+        start_time="3pm",
+        end_time="5pm",
+        end_date="2026-08-01",
+    )
+
+    assert result == tools._summarize(_recurring_slot())
+    body = json.loads(route.calls.last.request.read())
+    assert body["day_of_week"] == 5
+    assert body["start_time"] == "15:00"
+    assert body["end_time"] == "17:00"
+    assert body["end_date"] == "2026-08-01"
+    assert "credentials" in body
+    assert body["credentials"] not in ("alice:1234", "")
+    assert "1234" not in body["credentials"]
+
+
+@respx.mock
+async def test_create_recurring_wanted_surfaces_422(tools: Tools) -> None:
+    respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(422, json={"detail": "end_time must be after start_time"})
+    )
+    result = await tools.create_recurring_wanted(
+        day_of_week="sat", start_time="5pm", end_time="3pm"
+    )
+    assert "error" in result and "end_time must be after start_time" in result["error"]
+
+
+@respx.mock
+async def test_create_recurring_wanted_no_end_date_omits_field(tools: Tools) -> None:
+    route = respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(201, json=_recurring_slot(end_date=None))
+    )
+    await tools.create_recurring_wanted(
+        day_of_week="sat", start_time="3pm", end_time="5pm"
+    )
+    body = json.loads(route.calls.last.request.read())
+    assert "end_date" not in body
+
+
+async def test_create_recurring_wanted_bad_day(tools: Tools) -> None:
+    result = await tools.create_recurring_wanted(
+        day_of_week="funday", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "funday" in result["error"]

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -133,6 +133,17 @@ async def test_create_one_shot_wanted_surfaces_422(tools: Tools) -> None:
     assert "error" in result and "end_time must be after start_time" in result["error"]
 
 
+@respx.mock
+async def test_create_one_shot_wanted_handles_malformed_response(tools: Tools) -> None:
+    respx.post("http://api.test/api/wanted", params={"kind": "one_shot"}).mock(
+        return_value=httpx.Response(201, json={})
+    )
+    result = await tools.create_one_shot_wanted(
+        target_date="tomorrow", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "unexpected API response" in result["error"]
+
+
 def _recurring_slot(**over) -> dict:
     defaults = dict(
         kind="recurring",
@@ -177,6 +188,17 @@ async def test_create_recurring_wanted_surfaces_422(tools: Tools) -> None:
         day_of_week="sat", start_time="5pm", end_time="3pm"
     )
     assert "error" in result and "end_time must be after start_time" in result["error"]
+
+
+@respx.mock
+async def test_create_recurring_wanted_handles_malformed_response(tools: Tools) -> None:
+    respx.post("http://api.test/api/wanted", params={"kind": "recurring"}).mock(
+        return_value=httpx.Response(201, json={})
+    )
+    result = await tools.create_recurring_wanted(
+        day_of_week="sat", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "unexpected API response" in result["error"]
 
 
 @respx.mock

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -286,3 +286,40 @@ async def test_update_wanted_404(tools: Tools) -> None:
     )
     result = await tools.update_wanted(wanted_id="missing", num_slots=2)
     assert "error" in result and "not found" in result["error"]
+
+
+@respx.mock
+async def test_set_wanted_enabled_false_sends_disabled_true(tools: Tools) -> None:
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(status="disabled"))
+    )
+    result = await tools.set_wanted_enabled(wanted_id="w-1", enabled=False)
+    assert result == tools._summarize(_slot(status="disabled"))
+    assert json.loads(route.calls.last.request.read()) == {"disabled": True}
+
+
+@respx.mock
+async def test_set_wanted_enabled_true_sends_disabled_false(tools: Tools) -> None:
+    route = respx.patch("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(200, json=_slot(status="pending"))
+    )
+    await tools.set_wanted_enabled(wanted_id="w-1", enabled=True)
+    assert json.loads(route.calls.last.request.read()) == {"disabled": False}
+
+
+@respx.mock
+async def test_delete_wanted_ok(tools: Tools) -> None:
+    respx.delete("http://api.test/api/wanted/w-1").mock(
+        return_value=httpx.Response(204)
+    )
+    result = await tools.delete_wanted(wanted_id="w-1")
+    assert result == {"deleted": True, "id": "w-1"}
+
+
+@respx.mock
+async def test_delete_wanted_404(tools: Tools) -> None:
+    respx.delete("http://api.test/api/wanted/missing").mock(
+        return_value=httpx.Response(404, json={"detail": "Wanted slot not found"})
+    )
+    result = await tools.delete_wanted(wanted_id="missing")
+    assert "error" in result and "not found" in result["error"]

--- a/mcp/tests/test_wanted_tools.py
+++ b/mcp/tests/test_wanted_tools.py
@@ -1,6 +1,7 @@
 """Tests for the wanted-tee-time MCP tools."""
 
 import datetime as dt
+import json
 
 import httpx
 import pytest
@@ -34,7 +35,7 @@ async def tools(config: Config):
         router.post("http://api.test/api/login").mock(return_value=_login_response())
         async with httpx.AsyncClient() as http:
             api = ApiClient(config, AuthManager(config, http), http)
-            yield Tools(config=config, api=api, today=lambda: dt.date(2026, 5, 19))
+            yield Tools(config=config, api=api, today=lambda: dt.date(2026, 5, 20))
 
 
 def _slot(**over) -> dict:
@@ -85,3 +86,48 @@ def test_summarize_trims_and_keeps_last_outcome() -> None:
 
 def test_summarize_no_attempts() -> None:
     assert Tools._summarize(_slot())["last_outcome"] is None
+
+
+@respx.mock
+async def test_create_one_shot_wanted_ok(tools: Tools) -> None:
+    route = respx.post("http://api.test/api/wanted", params={"kind": "one_shot"}).mock(
+        return_value=httpx.Response(201, json=_slot())
+    )
+
+    result = await tools.create_one_shot_wanted(
+        target_date="next wednesday",
+        start_time="3pm",
+        end_time="5pm",
+        num_slots=2,
+        partners=["p1"],
+    )
+
+    assert result == tools._summarize(_slot())
+    body = json.loads(route.calls.last.request.read())
+    assert body["target_date"] == "2026-05-27"  # today=2026-05-20 (Wed) -> next Wed = 2026-05-27
+    assert body["start_time"] == "15:00"
+    assert body["end_time"] == "17:00"
+    assert body["num_slots"] == 2
+    assert body["partners"] == ["p1"]
+    # credentials auto-encrypted, never plaintext
+    assert "credentials" in body
+    assert body["credentials"] not in ("alice:1234", "")
+    assert "1234" not in body["credentials"]
+
+
+async def test_create_one_shot_wanted_bad_date(tools: Tools) -> None:
+    result = await tools.create_one_shot_wanted(
+        target_date="blursday", start_time="3pm", end_time="5pm"
+    )
+    assert "error" in result and "blursday" in result["error"]
+
+
+@respx.mock
+async def test_create_one_shot_wanted_surfaces_422(tools: Tools) -> None:
+    respx.post("http://api.test/api/wanted", params={"kind": "one_shot"}).mock(
+        return_value=httpx.Response(422, json={"detail": "end_time must be after start_time"})
+    )
+    result = await tools.create_one_shot_wanted(
+        target_date="tomorrow", start_time="5pm", end_time="3pm"
+    )
+    assert "error" in result and "end_time must be after start_time" in result["error"]


### PR DESCRIPTION
Adds 7 MCP tools that proxy the REST API's `/api/wanted` endpoints, exposing the persisted auto-booking ("wanted tee-times") feature to Claude Desktop / MetaMCP:
- `create_one_shot_wanted` / `create_recurring_wanted` — credentials auto-encrypted from server config (never a tool argument); natural-language dates and weekday names (0=Monday…6=Sunday).
- `list_wanted` (optional status filter), `get_wanted` (full attempt history).
- `update_wanted` (edits only provided mutable fields), `set_wanted_enabled` (pause/resume), `delete_wanted`.
Supporting changes: `parse_day_of_week` helper in `dates.py`, `params=` support on `ApiClient.post`/`.patch`, new `ApiClient.delete`, a `Tools._summarize` response shaper, server registration with LLM-facing descriptions, and docs (`mcp/README.md`, `CLAUDE.md`).
Out of scope (deliberately excluded per spec): SMS notify, per-call credential override, editing kind/target_date/day_of_week.
Spec: `docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md`
Plan: `docs/superpowers/plans/2026-05-19-wanted-tee-times-mcp-tools.md`
- [x] `cd mcp && uv run pytest` — 88 passing
- [ ] Smoke-test the registered tools via Claude Desktop / MetaMCP against a running API
🤖 Generated with [Claude Code](https://claude.com/claude-code)