### PR TITLE
fix(helm): correct cli image repository name

### DIFF
--- a/charts/tee-sniper-api/values.yaml
+++ b/charts/tee-sniper-api/values.yaml
@@ -24,7 +24,7 @@ api:
 
 cli:
   image:
-    repository: ghcr.io/stebennett/tee-sniper-cli
+    repository: ghcr.io/stebennett/tee-sniper
     tag: ""
     pullPolicy: IfNotPresent
   existingSecret: tee-sniper-cli


### PR DESCRIPTION
The Helm chart pointed the CLI CronJob image at a repository that is never published.
- `charts/tee-sniper-api/values.yaml` set `cli.image.repository: ghcr.io/stebennett/tee-sniper-cli`.
- The release workflow uses `IMAGE_NAME = github.repository`, so it publishes the **CLI** image at the bare `ghcr.io/stebennett/tee-sniper` and only adds `-api` / `-mcp` suffixes for the other two images.
- As a result, any CronJob rendered from this chart referenced a non-existent `-cli` image.
This changes `cli.image.repository` to `ghcr.io/stebennett/tee-sniper` to match the published image. Scope is limited to the image repository; `existingSecret: tee-sniper-cli` and README references are left unchanged.
- `helm template` with a cronjob now renders `image: "ghcr.io/stebennett/tee-sniper:0.1.0"`.
- `helm template` with default values succeeds.
🤖 Generated with [Claude Code](https://claude.com/claude-code)