### PR TITLE
Wanted tee-times web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ TSA_LOG_FORMAT=json
 
 # Optional: Debug mode (set to true for development)
 TSA_DEBUG=false
+
+# Optional: Path to a JSON file mapping partner IDs to display names.
+# See api/partners.example.json for the format ({ "id": "name", ... }).
+TSA_PARTNERS_FILE=api/partners.example.json

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,59 @@
+name: Web Build and Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-build.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-build.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./web
+          push: false
+          tags: tee-sniper-web:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .env
 
 .worktrees/
+.claude/
+.superpowers/
 
 # Helm: don't commit pulled subcharts (Chart.lock pins them)
 charts/*/charts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,25 @@ time-of-day bands, and Claude Desktop / MetaMCP config snippets.
 - Shipped via PR #71 (single PR covering all 5 phases — A: API endpoint,
   B: scaffold, C: tools, D: Docker+CI, E: docs).
 - Wanted tee-time MCP tools spec: `docs/superpowers/specs/2026-05-19-wanted-tee-times-mcp-tools-design.md`; plan: `docs/superpowers/plans/2026-05-19-wanted-tee-times-mcp-tools.md`.
+
+## Web UI (`web/`)
+
+React SPA for the wanted tee-times workflow. Login + full CRUD over
+`/api/wanted`. Stack: Vite + React + TypeScript + Tailwind + TanStack
+Query + React Router + Zod + react-hook-form + Vitest + MSW. Deployed via
+`charts/tee-sniper-web` (nginx serving the `dist/` baked into the image).
+
+```bash
+cd web
+npm install
+npm run dev    # :5173, proxies /api to http://localhost:8000
+npm test
+npm run build
+```
+
+The browser never sees the AES shared secret. It calls
+`POST /api/encrypt-credentials` (added in this iteration) to get an
+encrypted blob used by `/api/login` and by wanted-slot create.
+
+- Spec: `docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md`
+- Plan: `docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,21 @@ The repository includes CI workflows in `.github/workflows/`:
   (`ghcr.io/<repo>-api`), the MCP image (`ghcr.io/<repo>-mcp`), and the
   MCP wheel + sdist as release assets
 
+## Git Worktrees
+
+Create worktrees for parallel feature work under `.claude/worktrees/<branch-slug>`
+inside this repository (not as siblings of the repo root). Use the branch
+name with `/` replaced by `-` as the directory slug.
+
+```bash
+git worktree add -b feat/foo .claude/worktrees/feat-foo origin/main
+cd .claude/worktrees/feat-foo
+```
+
+`.claude/` is git-ignored, so the worktree files are not tracked. When the
+branch is merged, remove the worktree with
+`git worktree remove .claude/worktrees/<slug>`.
+
 ## API Migration Workflow
 
 When implementing the API migration plan (see `docs/API_MIGRATION_PLAN.md`):

--- a/api/app/models/requests.py
+++ b/api/app/models/requests.py
@@ -40,3 +40,10 @@ class AddPartnersRequest(BaseModel):
         default=False,
         description="If true, simulate partner addition without making changes",
     )
+
+
+class EncryptRequest(BaseModel):
+    """Plaintext credentials for server-side encryption."""
+
+    username: str = Field(..., min_length=1)
+    pin: str = Field(..., min_length=1)

--- a/api/app/models/responses.py
+++ b/api/app/models/responses.py
@@ -85,3 +85,12 @@ class ErrorResponse(BaseModel):
     """Standard error response."""
 
     detail: str = Field(..., description="Error description")
+
+
+class EncryptResponse(BaseModel):
+    """Encrypted credentials blob produced by /api/encrypt-credentials."""
+
+    credentials: str = Field(
+        ...,
+        description="AES-256-GCM encrypted 'username:pin', base64 encoded",
+    )

--- a/api/app/routers/booking.py
+++ b/api/app/routers/booking.py
@@ -16,11 +16,12 @@ from app.dependencies import (
     get_session_manager,
     get_settings_dependency,
 )
-from app.models.requests import AddPartnersRequest, BookRequest, LoginRequest
+from app.models.requests import AddPartnersRequest, BookRequest, EncryptRequest, LoginRequest
 from app.models.responses import (
     AddPartnersResponse,
     AvailabilityResponse,
     BookResponse,
+    EncryptResponse,
     ErrorResponse,
     LoginResponse,
     PartnerResponse,
@@ -89,6 +90,29 @@ async def login(
     expires_at = datetime.datetime.now(timezone.utc) + timedelta(seconds=session_manager.ttl)
 
     return LoginResponse(access_token=token, expires_at=expires_at)
+
+
+@router.post(
+    "/encrypt-credentials",
+    response_model=EncryptResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        422: {"model": ErrorResponse, "description": "Invalid request body"},
+    },
+    summary="Encrypt credentials with the server's shared secret",
+)
+async def encrypt_credentials(
+    body: EncryptRequest,
+    encryption: EncryptionService = Depends(get_encryption_service),
+) -> EncryptResponse:
+    """Encrypt 'username:pin' for use in /api/login and wanted-slot storage.
+
+    Auth-free: login cannot precede this call, and the booking site itself
+    validates whether the credentials are real on the subsequent /api/login.
+    """
+    return EncryptResponse(
+        credentials=encryption.encrypt_credentials(body.username, body.pin),
+    )
 
 
 @router.get(

--- a/api/partners.example.json
+++ b/api/partners.example.json
@@ -1,0 +1,6 @@
+{
+  "10001": "Alice Morgan",
+  "10002": "Bob Chen",
+  "10003": "Carol Diaz",
+  "10004": "David Okafor"
+}

--- a/api/tests/test_booking_routes.py
+++ b/api/tests/test_booking_routes.py
@@ -779,3 +779,28 @@ class TestPartnersEndpoint:
         _app, client = app_and_client
         response = client.get("/api/partners")
         assert response.status_code == 401  # No auth header → 401 Unauthorized
+
+
+def test_encrypt_credentials_roundtrip(
+    app_and_client: tuple,
+    encryption_service: EncryptionService,
+) -> None:
+    """POST /api/encrypt-credentials returns a blob the server can decrypt."""
+    _app, client = app_and_client
+    resp = client.post(
+        "/api/encrypt-credentials",
+        json={"username": "alice", "pin": "1234"},
+    )
+    assert resp.status_code == 200
+    blob = resp.json()["credentials"]
+    assert isinstance(blob, str) and len(blob) > 0
+
+    username, pin = encryption_service.decrypt_credentials(blob)
+    assert (username, pin) == ("alice", "1234")
+
+
+def test_encrypt_credentials_validation(app_and_client: tuple) -> None:
+    """Missing fields → 422."""
+    _app, client = app_and_client
+    resp = client.post("/api/encrypt-credentials", json={"username": "x"})
+    assert resp.status_code == 422

--- a/charts/tee-sniper-web/Chart.yaml
+++ b/charts/tee-sniper-web/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: tee-sniper-web
+description: nginx-served React UI for tee-sniper wanted tee-times
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.27.0"
+home: https://github.com/stebennett/tee-sniper
+sources:
+  - https://github.com/stebennett/tee-sniper
+maintainers:
+  - name: Steve Bennett

--- a/charts/tee-sniper-web/templates/_helpers.tpl
+++ b/charts/tee-sniper-web/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{- define "tee-sniper-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tee-sniper-web.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tee-sniper-web.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "tee-sniper-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "tee-sniper-web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tee-sniper-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "tee-sniper-web.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}

--- a/charts/tee-sniper-web/templates/deployment.yaml
+++ b/charts/tee-sniper-web/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "tee-sniper-web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "tee-sniper-web.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: web
+          image: {{ include "tee-sniper-web.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          env:
+            - name: API_BASE_URL
+              value: {{ .Values.apiBaseUrl | quote }}
+          readinessProbe:
+            httpGet: { path: /, port: 80 }
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tee-sniper-web/templates/ingress.yaml
+++ b/charts/tee-sniper-web/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts: [{{ .Values.ingress.host | quote }}]
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.apiServiceName }}
+                port: { number: {{ .Values.ingress.apiServicePort }} }
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tee-sniper-web.fullname" . }}
+                port: { number: {{ .Values.service.port }} }
+{{- end }}

--- a/charts/tee-sniper-web/templates/service.yaml
+++ b/charts/tee-sniper-web/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector: {{- include "tee-sniper-web.selectorLabels" . | nindent 4 }}

--- a/charts/tee-sniper-web/values.yaml
+++ b/charts/tee-sniper-web/values.yaml
@@ -1,0 +1,36 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/stebennett/tee-sniper-web
+  tag: ""              # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+# Empty string → browser uses relative /api/* (same-host ingress).
+apiBaseUrl: ""
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  host: tee-sniper.example.com
+  tls:
+    enabled: false
+    secretName: ""
+  # Path-based split: /api/* → API service, /* → this service.
+  apiServiceName: tee-sniper-api
+  apiServicePort: 80
+
+resources:
+  limits:   { cpu: 100m, memory: 64Mi }
+  requests: { cpu: 10m,  memory: 32Mi }
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - .env
     environment:
       - TSA_REDIS_URL=redis://redis:6379/0
+      - TSA_PARTNERS_FILE=/app/partners.json
+    volumes:
+      - ./api/partners.example.json:/app/partners.json:ro
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,28 @@ services:
       start_period: 10s
     restart: unless-stopped
 
+  web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    environment:
+      # The browser runs on the host, so it reaches the API via the published
+      # host port — not the internal `api` hostname. This is cross-origin, so it
+      # relies on the API's debug-mode CORS (enabled by docker-compose.override.yml).
+      - API_BASE_URL=http://localhost:8000
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
   redis:
     image: redis:8-alpine
     ports:

--- a/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
+++ b/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
@@ -2021,8 +2021,13 @@ export function LoginPage() {
   });
 
   const onSubmit = handleSubmit(async (values) => {
-    await m.mutateAsync(values);
-    navigate('/wanted');
+    try {
+      await m.mutateAsync(values);
+      navigate('/wanted');
+    } catch {
+      // Error is surfaced via m.error; swallow the rejection so it
+      // doesn't escape as an unhandled promise rejection (fails CI).
+    }
   });
 
   const errorMsg =

--- a/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
+++ b/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
@@ -1,6 +1,6 @@
 # Wanted Tee-Times Web UI Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development with sonnet sub-agents (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship a React SPA at `web/` covering login + full CRUD over wanted tee-time requests, served behind nginx via a new Helm chart, plus the one backend endpoint that lets the browser produce encrypted credentials.
 
@@ -55,14 +55,21 @@
 
 - [ ] **Step 1: Create the worktree from main**
 
+Worktrees for this repo live under `.claude/worktrees/` (see `CLAUDE.md`).
+This step is performed by the controller before dispatching subagents; the
+controller also cherry-picks the spec + plan commits from `main` so the
+branch contains them. Subagents start from Step 2.
+
 ```bash
 cd /Users/stevebennett/Code/tee-sniper
 git fetch origin
-git worktree add -b web/wanted-ui ../tee-sniper-web-ui origin/main
-cd ../tee-sniper-web-ui
+git worktree add -b web/wanted-ui .claude/worktrees/web-wanted-ui origin/main
+cd .claude/worktrees/web-wanted-ui
+# Cherry-pick spec + plan commits (the two newest on main):
+git cherry-pick <spec-sha> <plan-sha>
 ```
 
-All subsequent tasks assume `cwd = /Users/stevebennett/Code/tee-sniper-web-ui` and branch `web/wanted-ui`.
+All subsequent tasks assume `cwd = /Users/stevebennett/Code/tee-sniper/.claude/worktrees/web-wanted-ui` and branch `web/wanted-ui`.
 
 - [ ] **Step 2: Sanity check**
 
@@ -3194,7 +3201,7 @@ Expected: all pass.
 - [ ] **Step 2: Whole-repo regression — Go tests**
 
 ```bash
-cd /Users/stevebennett/Code/tee-sniper-web-ui
+cd /Users/stevebennett/Code/tee-sniper/.claude/worktrees/web-wanted-ui
 go test ./...
 ```
 

--- a/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
+++ b/docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md
@@ -1,0 +1,3258 @@
+# Wanted Tee-Times Web UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a React SPA at `web/` covering login + full CRUD over wanted tee-time requests, served behind nginx via a new Helm chart, plus the one backend endpoint that lets the browser produce encrypted credentials.
+
+**Architecture:** New top-level package `web/` (Vite + React + TypeScript + Tailwind + TanStack Query + React Router + Zod + Vitest + MSW). All API calls go through a single typed fetch wrapper; auth state lives in a React context (token in sessionStorage, encrypted-credentials blob in memory only). One new FastAPI endpoint `POST /api/encrypt-credentials` lets the browser request encryption without holding the shared secret. Deployment: a multi-stage Docker image (node build → `nginx:alpine` serving `dist/`) deployed via a new `charts/tee-sniper-web` chart; ingress routes `/api/*` to the API service and `/*` to the web service, so the browser uses relative URLs and CORS is unneeded.
+
+**Tech Stack:** React 18, TypeScript 5, Vite 5, Tailwind CSS 3, TanStack Query v5, React Router v6, Zod 3, react-hook-form, sonner (toasts), Vitest, @testing-library/react, MSW v2, nginx:alpine.
+
+**Workflow:** Per the user's preference, deliver as a **single combined PR** off a worktree from `main`, branch `web/wanted-ui`. Subagent implementers commit locally; the controller handles push/PR.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md`.
+
+---
+
+## File map
+
+**Created**
+- `web/package.json`, `web/package-lock.json`
+- `web/vite.config.ts`, `web/tsconfig.json`, `web/tsconfig.node.json`
+- `web/tailwind.config.ts`, `web/postcss.config.js`
+- `web/.eslintrc.cjs`, `web/.gitignore`
+- `web/index.html`
+- `web/src/main.tsx`, `web/src/App.tsx`, `web/src/router.tsx`, `web/src/index.css`
+- `web/src/config.ts`
+- `web/src/api/types.ts`, `web/src/api/client.ts`, `web/src/api/endpoints.ts`
+- `web/src/auth/AuthProvider.tsx`, `web/src/auth/useAuth.ts`, `web/src/auth/ProtectedRoute.tsx`
+- `web/src/crypto/encrypt.ts`
+- `web/src/hooks/useWanted.ts`, `web/src/hooks/usePartners.ts`, `web/src/hooks/useLogin.ts`
+- `web/src/pages/LoginPage.tsx`, `web/src/pages/WantedListPage.tsx`, `web/src/pages/WantedNewPage.tsx`, `web/src/pages/WantedDetailPage.tsx`
+- `web/src/components/{StatusPill,WantedCard,ConfirmDialog,NotifyFields,PartnerPicker,AttemptList,OneShotForm,RecurringForm,SlotFormFields}.tsx`
+- `web/src/lib/format.ts`, `web/src/lib/schemas.ts`
+- `web/test/setup.ts`, `web/test/handlers.ts`, `web/test/utils.tsx`
+- `web/src/**/*.test.ts(x)` — co-located component/unit tests
+- `web/Dockerfile`, `web/nginx.conf`, `web/entrypoint.sh`, `web/README.md`
+- `charts/tee-sniper-web/Chart.yaml`, `charts/tee-sniper-web/values.yaml`
+- `charts/tee-sniper-web/templates/{deployment,service,ingress,configmap,_helpers.tpl}.yaml`
+- `.github/workflows/web-build.yml`
+- `api/app/models/requests.py` — add `EncryptRequest`
+- `api/app/models/responses.py` — add `EncryptResponse`
+- `api/tests/test_booking_routes.py` — add encrypt-credentials roundtrip test
+
+**Modified**
+- `api/app/routers/booking.py` — add `POST /api/encrypt-credentials`
+- `CLAUDE.md` — add "Web UI" section
+- `.gitignore` — add `web/node_modules`, `web/dist`, `.superpowers/`
+
+---
+
+## Task 0: Worktree + branch
+
+**Files:**
+- (none)
+
+- [ ] **Step 1: Create the worktree from main**
+
+```bash
+cd /Users/stevebennett/Code/tee-sniper
+git fetch origin
+git worktree add -b web/wanted-ui ../tee-sniper-web-ui origin/main
+cd ../tee-sniper-web-ui
+```
+
+All subsequent tasks assume `cwd = /Users/stevebennett/Code/tee-sniper-web-ui` and branch `web/wanted-ui`.
+
+- [ ] **Step 2: Sanity check**
+
+```bash
+git status
+git log --oneline -1
+```
+
+Expected: clean tree, HEAD matches `origin/main`.
+
+---
+
+## Task 1: Backend — `POST /api/encrypt-credentials`
+
+**Files:**
+- Modify: `api/app/models/requests.py`
+- Modify: `api/app/models/responses.py`
+- Modify: `api/app/routers/booking.py`
+- Test: `api/tests/test_booking_routes.py`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `api/tests/test_booking_routes.py`:
+
+```python
+def test_encrypt_credentials_roundtrip(client, encryption_service):
+    """POST /api/encrypt-credentials returns a blob the server can decrypt."""
+    resp = client.post(
+        "/api/encrypt-credentials",
+        json={"username": "alice", "pin": "1234"},
+    )
+    assert resp.status_code == 200
+    blob = resp.json()["credentials"]
+    assert isinstance(blob, str) and len(blob) > 0
+
+    username, pin = encryption_service.decrypt_credentials(blob)
+    assert (username, pin) == ("alice", "1234")
+
+
+def test_encrypt_credentials_validation():
+    """Missing fields → 422."""
+    from fastapi.testclient import TestClient
+    from app.main import app
+    resp = TestClient(app).post("/api/encrypt-credentials", json={"username": "x"})
+    assert resp.status_code == 422
+```
+
+If `encryption_service` fixture does not yet exist, add to `api/tests/conftest.py`:
+
+```python
+import pytest
+from app.services.encryption import EncryptionService
+from app.config import get_settings
+
+@pytest.fixture
+def encryption_service() -> EncryptionService:
+    return EncryptionService(get_settings().shared_secret)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd api && .venv/bin/python -m pytest tests/test_booking_routes.py::test_encrypt_credentials_roundtrip -v
+```
+
+Expected: FAIL — 404 on the endpoint.
+
+- [ ] **Step 3: Add `EncryptRequest` to `api/app/models/requests.py`**
+
+Append at end:
+
+```python
+class EncryptRequest(BaseModel):
+    """Plaintext credentials for server-side encryption."""
+
+    username: str = Field(..., min_length=1)
+    pin: str = Field(..., min_length=1)
+```
+
+- [ ] **Step 4: Add `EncryptResponse` to `api/app/models/responses.py`**
+
+Append at end:
+
+```python
+class EncryptResponse(BaseModel):
+    """Encrypted credentials blob produced by /api/encrypt-credentials."""
+
+    credentials: str = Field(
+        ...,
+        description="AES-256-GCM encrypted 'username:pin', base64 encoded",
+    )
+```
+
+- [ ] **Step 5: Add the route in `api/app/routers/booking.py`**
+
+Add to the imports near the top (extend the existing ones):
+
+```python
+from app.models.requests import (
+    AddPartnersRequest,
+    BookRequest,
+    EncryptRequest,
+    LoginRequest,
+)
+from app.models.responses import (
+    # ...existing names...
+    EncryptResponse,
+)
+```
+
+Append a new route below `login`:
+
+```python
+@router.post(
+    "/encrypt-credentials",
+    response_model=EncryptResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        422: {"model": ErrorResponse, "description": "Invalid request body"},
+    },
+    summary="Encrypt credentials with the server's shared secret",
+)
+async def encrypt_credentials(
+    body: EncryptRequest,
+    encryption: EncryptionService = Depends(get_encryption_service),
+) -> EncryptResponse:
+    """Encrypt 'username:pin' for use in /api/login and wanted-slot storage.
+
+    Auth-free: login cannot precede this call, and the booking site itself
+    validates whether the credentials are real on the subsequent /api/login.
+    """
+    return EncryptResponse(
+        credentials=encryption.encrypt_credentials(body.username, body.pin),
+    )
+```
+
+- [ ] **Step 6: Run both tests, verify pass**
+
+```bash
+cd api && .venv/bin/python -m pytest tests/test_booking_routes.py -v -k encrypt
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 7: Run the full api suite as a regression check**
+
+```bash
+cd api && .venv/bin/python -m pytest tests/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/app/models/requests.py api/app/models/responses.py \
+        api/app/routers/booking.py api/tests/test_booking_routes.py \
+        api/tests/conftest.py
+git commit -m "feat(api): add POST /api/encrypt-credentials"
+```
+
+---
+
+## Task 2: Scaffold the `web/` package
+
+**Files:**
+- Create: `web/package.json`, `web/vite.config.ts`, `web/tsconfig.json`, `web/tsconfig.node.json`, `web/tailwind.config.ts`, `web/postcss.config.js`, `web/.eslintrc.cjs`, `web/.gitignore`, `web/index.html`, `web/src/main.tsx`, `web/src/App.tsx`, `web/src/index.css`, `web/src/vite-env.d.ts`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create `web/package.json`**
+
+```json
+{
+  "name": "tee-sniper-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.0",
+    "react-router-dom": "^6.26.0",
+    "sonner": "^1.5.0",
+    "zod": "^3.23.0",
+    "@hookform/resolvers": "^3.9.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/parser": "^7.16.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "jsdom": "^24.1.0",
+    "msw": "^2.3.0",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.6",
+    "typescript": "^5.5.0",
+    "vite": "^5.3.0",
+    "vitest": "^2.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `web/vite.config.ts`**
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+    globals: true,
+    css: false,
+  },
+});
+```
+
+- [ ] **Step 3: Create `web/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "test"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+```
+
+- [ ] **Step 4: Create `web/tsconfig.node.json`**
+
+```json
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}
+```
+
+- [ ] **Step 5: Create `web/tailwind.config.ts`**
+
+```ts
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config;
+```
+
+- [ ] **Step 6: Create `web/postcss.config.js`**
+
+```js
+export default {
+  plugins: { tailwindcss: {}, autoprefixer: {} },
+};
+```
+
+- [ ] **Step 7: Create `web/.eslintrc.cjs`**
+
+```js
+module.exports = {
+  root: true,
+  env: { browser: true, es2022: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': 'warn',
+  },
+};
+```
+
+- [ ] **Step 8: Create `web/.gitignore`**
+
+```
+node_modules
+dist
+coverage
+.env.local
+```
+
+- [ ] **Step 9: Create `web/index.html`**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tee Sniper</title>
+    <script src="/config.js"></script>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 10: Create `web/src/index.css`**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+- [ ] **Step 11: Create `web/src/vite-env.d.ts`**
+
+```ts
+/// <reference types="vite/client" />
+
+declare global {
+  interface Window {
+    __TSA_CONFIG__?: { apiBaseUrl?: string };
+  }
+}
+
+export {};
+```
+
+- [ ] **Step 12: Create `web/src/main.tsx`**
+
+```tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+```
+
+- [ ] **Step 13: Create placeholder `web/src/App.tsx`**
+
+```tsx
+export function App() {
+  return <div className="p-8">Tee Sniper — bootstrapping…</div>;
+}
+```
+
+- [ ] **Step 14: Update root `.gitignore`**
+
+Append:
+
+```
+.superpowers/
+```
+
+(Already covered by `web/.gitignore`, but `.superpowers/` is the brainstorm dir.)
+
+- [ ] **Step 15: Install dependencies and run a build smoke test**
+
+```bash
+cd web && npm install
+npm run build
+```
+
+Expected: clean install (no peer-dep errors that fail the install), `dist/` produced.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add web/ .gitignore
+git commit -m "chore(web): scaffold Vite + React + TS + Tailwind"
+```
+
+---
+
+## Task 3: Test infrastructure (Vitest + MSW)
+
+**Files:**
+- Create: `web/test/setup.ts`, `web/test/handlers.ts`, `web/test/utils.tsx`
+
+- [ ] **Step 1: Create `web/test/setup.ts`**
+
+```ts
+import '@testing-library/jest-dom/vitest';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from './handlers';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+- [ ] **Step 2: Create `web/test/handlers.ts`**
+
+```ts
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+export const baseUrl = 'http://api.test';
+
+// Default happy-path handlers. Individual tests override per-case.
+export const handlers = [
+  http.post(`${baseUrl}/api/encrypt-credentials`, async ({ request }) => {
+    const body = (await request.json()) as { username: string; pin: string };
+    return HttpResponse.json({ credentials: `enc(${body.username}:${body.pin})` });
+  }),
+  http.post(`${baseUrl}/api/login`, () =>
+    HttpResponse.json({
+      access_token: 'test-token',
+      expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    }),
+  ),
+  http.get(`${baseUrl}/api/wanted`, () => HttpResponse.json([])),
+  http.get(`${baseUrl}/api/partners`, () => HttpResponse.json({ partners: [] })),
+];
+
+export const server = setupServer(...handlers);
+```
+
+- [ ] **Step 3: Create `web/test/utils.tsx`**
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../src/auth/AuthProvider';
+
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = '/', initialAuth }: { route?: string; initialAuth?: Parameters<typeof AuthProvider>[0]['initial'] } = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[route]}>
+        <AuthProvider initial={initialAuth}>{ui}</AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+```
+
+`AuthProvider` is defined in Task 5. This file will not type-check yet — that's fine; first real test that imports `renderWithProviders` arrives in Task 5.
+
+- [ ] **Step 4: Smoke-test vitest startup**
+
+```bash
+cd web && npx vitest run --reporter verbose
+```
+
+Expected: "No test files found." (or "0 passed") with no setup errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/test/
+git commit -m "test(web): add vitest setup + MSW handlers"
+```
+
+---
+
+## Task 4: API types + client
+
+**Files:**
+- Create: `web/src/api/types.ts`, `web/src/api/client.ts`, `web/src/api/endpoints.ts`, `web/src/config.ts`
+- Test: `web/src/api/client.test.ts`, `web/src/api/endpoints.test.ts`
+
+- [ ] **Step 1: Create `web/src/config.ts`**
+
+```ts
+export function apiBaseUrl(): string {
+  // Runtime override via /config.js → window.__TSA_CONFIG__.
+  // Tests inject http://api.test via vitest globals.
+  if (typeof window !== 'undefined' && window.__TSA_CONFIG__?.apiBaseUrl !== undefined) {
+    return window.__TSA_CONFIG__.apiBaseUrl;
+  }
+  return '';
+}
+```
+
+- [ ] **Step 2: Create `web/src/api/types.ts`**
+
+Hand-mirrored from `api/app/models/wanted.py` + `requests.py` + `responses.py`:
+
+```ts
+export type WantedKind = 'one_shot' | 'recurring';
+export type WantedStatus = 'pending' | 'booked' | 'expired' | 'disabled';
+export type Outcome =
+  | 'booked' | 'no_slots' | 'auth_failed' | 'upstream_error' | 'booking_failed';
+
+export interface Notify { to: string; from?: string }
+
+export interface Attempt {
+  ts: string;
+  target_date: string;
+  outcome: Outcome;
+  booking_id?: string | null;
+  error?: string | null;
+}
+
+export interface WantedResponse {
+  id: string;
+  kind: WantedKind;
+  target_date: string | null;
+  day_of_week: number | null;
+  end_date: string | null;
+  start_time: string;
+  end_time: string;
+  num_slots: number;
+  partners: string[];
+  has_credentials: boolean;
+  notify: Notify | null;
+  status: WantedStatus;
+  attempts: Attempt[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LoginRequest { credentials: string }
+export interface LoginResponse { access_token: string; expires_at: string }
+
+export interface EncryptRequest { username: string; pin: string }
+export interface EncryptResponse { credentials: string }
+
+export interface CreateOneShotRequest {
+  target_date: string;          // YYYY-MM-DD
+  start_time: string;           // HH:MM
+  end_time: string;             // HH:MM
+  num_slots: number;
+  partners: string[];
+  credentials: string;
+  notify?: Notify | null;
+}
+
+export interface CreateRecurringRequest {
+  day_of_week: number;          // 0=Mon ... 6=Sun (matches Python weekday())
+  end_date?: string | null;
+  start_time: string;
+  end_time: string;
+  num_slots: number;
+  partners: string[];
+  credentials: string;
+  notify?: Notify | null;
+}
+
+export interface PatchWantedRequest {
+  start_time?: string;
+  end_time?: string;
+  num_slots?: number;
+  partners?: string[];
+  notify?: Notify | null;
+  disabled?: boolean;
+  credentials?: string;
+}
+
+export interface Partner { id: string; name: string }
+export interface PartnerListResponse { partners: Partner[] }
+```
+
+- [ ] **Step 3: Write failing tests for `client.ts`**
+
+`web/src/api/client.test.ts`:
+
+```ts
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server, baseUrl } from '../../test/handlers';
+import { ApiError, request } from './client';
+
+// Force apiBaseUrl() to return baseUrl during tests.
+beforeAll(() => {
+  window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl };
+});
+
+describe('request', () => {
+  it('returns parsed JSON on 2xx', async () => {
+    server.use(http.get(`${baseUrl}/ok`, () => HttpResponse.json({ hello: 'world' })));
+    await expect(request<{ hello: string }>('/ok')).resolves.toEqual({ hello: 'world' });
+  });
+
+  it('throws ApiError with detail on non-2xx', async () => {
+    server.use(
+      http.get(`${baseUrl}/bad`, () =>
+        HttpResponse.json({ detail: 'nope' }, { status: 422 }),
+      ),
+    );
+    await expect(request('/bad')).rejects.toBeInstanceOf(ApiError);
+    await expect(request('/bad')).rejects.toMatchObject({ status: 422, detail: 'nope' });
+  });
+
+  it('attaches Bearer token when provided', async () => {
+    let seenAuth: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/auth`, ({ request }) => {
+        seenAuth = request.headers.get('authorization');
+        return HttpResponse.json({});
+      }),
+    );
+    await request('/auth', { token: 'abc' });
+    expect(seenAuth).toBe('Bearer abc');
+  });
+
+  it('returns undefined for 204 No Content', async () => {
+    server.use(http.delete(`${baseUrl}/x`, () => new HttpResponse(null, { status: 204 })));
+    await expect(request('/x', { method: 'DELETE' })).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 4: Run, expect failure**
+
+```bash
+cd web && npm test -- src/api/client.test.ts
+```
+
+Expected: FAIL — `client.ts` does not exist.
+
+- [ ] **Step 5: Create `web/src/api/client.ts`**
+
+```ts
+import { apiBaseUrl } from '../config';
+
+export class ApiError extends Error {
+  constructor(public status: number, public detail: string) {
+    super(detail || `HTTP ${status}`);
+    this.name = 'ApiError';
+  }
+}
+
+export interface RequestOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+  token?: string | null;
+}
+
+export async function request<T = unknown>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const { token, body, headers, ...rest } = opts;
+  const init: RequestInit = {
+    ...rest,
+    headers: {
+      Accept: 'application/json',
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(headers as Record<string, string> | undefined),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  };
+
+  const resp = await fetch(`${apiBaseUrl()}${path}`, init);
+
+  if (resp.status === 204) return undefined as T;
+
+  const text = await resp.text();
+  const data = text ? safeParse(text) : null;
+
+  if (!resp.ok) {
+    const detail = typeof data === 'object' && data && 'detail' in data
+      ? String((data as { detail: unknown }).detail)
+      : text || resp.statusText;
+    throw new ApiError(resp.status, detail);
+  }
+  return data as T;
+}
+
+function safeParse(text: string): unknown {
+  try { return JSON.parse(text); } catch { return text; }
+}
+```
+
+- [ ] **Step 6: Run client tests, verify pass**
+
+```bash
+cd web && npm test -- src/api/client.test.ts
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 7: Write failing tests for `endpoints.ts`**
+
+`web/src/api/endpoints.test.ts`:
+
+```ts
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server, baseUrl } from '../../test/handlers';
+import * as api from './endpoints';
+
+beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+describe('endpoints', () => {
+  it('encryptCredentials posts plaintext', async () => {
+    const result = await api.encryptCredentials({ username: 'u', pin: 'p' });
+    expect(result.credentials).toBe('enc(u:p)');
+  });
+
+  it('login posts the blob', async () => {
+    const result = await api.login({ credentials: 'BLOB' });
+    expect(result.access_token).toBe('test-token');
+  });
+
+  it('listWanted sends the bearer token', async () => {
+    let auth: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/api/wanted`, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json([]);
+      }),
+    );
+    await api.listWanted('tok');
+    expect(auth).toBe('Bearer tok');
+  });
+
+  it('createWanted appends ?kind=', async () => {
+    let url: string | null = null;
+    server.use(
+      http.post(`${baseUrl}/api/wanted`, ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ id: 'x' }, { status: 201 });
+      }),
+    );
+    await api.createWanted('tok', 'one_shot', {
+      target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+      num_slots: 2, partners: [], credentials: 'BLOB',
+    });
+    expect(url).toContain('kind=one_shot');
+  });
+});
+```
+
+- [ ] **Step 8: Create `web/src/api/endpoints.ts`**
+
+```ts
+import { request } from './client';
+import type {
+  CreateOneShotRequest,
+  CreateRecurringRequest,
+  EncryptRequest,
+  EncryptResponse,
+  LoginRequest,
+  LoginResponse,
+  PartnerListResponse,
+  PatchWantedRequest,
+  WantedKind,
+  WantedResponse,
+} from './types';
+
+export function encryptCredentials(body: EncryptRequest): Promise<EncryptResponse> {
+  return request('/api/encrypt-credentials', { method: 'POST', body });
+}
+
+export function login(body: LoginRequest): Promise<LoginResponse> {
+  return request('/api/login', { method: 'POST', body });
+}
+
+export function listWanted(token: string): Promise<WantedResponse[]> {
+  return request('/api/wanted', { token });
+}
+
+export function getWanted(token: string, id: string): Promise<WantedResponse> {
+  return request(`/api/wanted/${id}`, { token });
+}
+
+export function createWanted(
+  token: string,
+  kind: WantedKind,
+  body: CreateOneShotRequest | CreateRecurringRequest,
+): Promise<WantedResponse> {
+  return request(`/api/wanted?kind=${kind}`, { method: 'POST', body, token });
+}
+
+export function patchWanted(
+  token: string,
+  id: string,
+  body: PatchWantedRequest,
+): Promise<WantedResponse> {
+  return request(`/api/wanted/${id}`, { method: 'PATCH', body, token });
+}
+
+export function deleteWanted(token: string, id: string): Promise<void> {
+  return request(`/api/wanted/${id}`, { method: 'DELETE', token });
+}
+
+export function listPartners(token: string): Promise<PartnerListResponse> {
+  return request('/api/partners', { token });
+}
+```
+
+- [ ] **Step 9: Run endpoint tests, verify pass**
+
+```bash
+cd web && npm test -- src/api/
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/api/ web/src/config.ts
+git commit -m "feat(web): typed API client + endpoints"
+```
+
+---
+
+## Task 5: Auth context + ProtectedRoute
+
+**Files:**
+- Create: `web/src/auth/AuthProvider.tsx`, `web/src/auth/useAuth.ts`, `web/src/auth/ProtectedRoute.tsx`
+- Test: `web/src/auth/AuthProvider.test.tsx`, `web/src/auth/ProtectedRoute.test.tsx`
+
+- [ ] **Step 1: Write failing test for `AuthProvider`**
+
+`web/src/auth/AuthProvider.test.tsx`:
+
+```tsx
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { AuthProvider } from './AuthProvider';
+import { useAuth } from './useAuth';
+
+function Probe() {
+  const a = useAuth();
+  return (
+    <div>
+      <span data-testid="token">{a.token ?? 'none'}</span>
+      <span data-testid="user">{a.username ?? 'none'}</span>
+      <button onClick={() => a.login('tok', 'alice', 'BLOB',
+                                     new Date('2099-01-01').toISOString())}>L</button>
+      <button onClick={() => a.logout()}>O</button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('starts logged out', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    expect(screen.getByTestId('token').textContent).toBe('none');
+  });
+
+  it('login() persists token + username to sessionStorage', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    expect(screen.getByTestId('token').textContent).toBe('tok');
+    expect(screen.getByTestId('user').textContent).toBe('alice');
+    expect(sessionStorage.getItem('tsa.token')).toBe('tok');
+    expect(sessionStorage.getItem('tsa.username')).toBe('alice');
+  });
+
+  it('logout() clears state and sessionStorage', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    act(() => { screen.getByText('O').click(); });
+    expect(screen.getByTestId('token').textContent).toBe('none');
+    expect(sessionStorage.getItem('tsa.token')).toBeNull();
+  });
+
+  it('rehydrates token from sessionStorage', () => {
+    sessionStorage.setItem('tsa.token', 'persisted');
+    sessionStorage.setItem('tsa.username', 'bob');
+    render(<AuthProvider><Probe /></AuthProvider>);
+    expect(screen.getByTestId('token').textContent).toBe('persisted');
+  });
+
+  it('does not persist credentialsBlob across reload', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    expect(sessionStorage.getItem('tsa.credentialsBlob')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd web && npm test -- src/auth/AuthProvider.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `web/src/auth/AuthProvider.tsx`**
+
+```tsx
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+export interface AuthState {
+  token: string | null;
+  username: string | null;
+  credentialsBlob: string | null;
+  expiresAt: string | null;
+}
+
+export interface AuthContextValue extends AuthState {
+  login: (token: string, username: string, credentialsBlob: string, expiresAt: string) => void;
+  logout: () => void;
+  setCredentialsBlob: (blob: string) => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+const TOKEN_KEY = 'tsa.token';
+const USER_KEY = 'tsa.username';
+const EXP_KEY = 'tsa.expiresAt';
+
+function readInitial(): AuthState {
+  if (typeof window === 'undefined') {
+    return { token: null, username: null, credentialsBlob: null, expiresAt: null };
+  }
+  return {
+    token: sessionStorage.getItem(TOKEN_KEY),
+    username: sessionStorage.getItem(USER_KEY),
+    expiresAt: sessionStorage.getItem(EXP_KEY),
+    credentialsBlob: null,
+  };
+}
+
+export function AuthProvider({
+  children,
+  initial,
+}: {
+  children: ReactNode;
+  initial?: Partial<AuthState>;
+}) {
+  const [state, setState] = useState<AuthState>(() => ({ ...readInitial(), ...initial }));
+
+  const login = useCallback(
+    (token: string, username: string, credentialsBlob: string, expiresAt: string) => {
+      sessionStorage.setItem(TOKEN_KEY, token);
+      sessionStorage.setItem(USER_KEY, username);
+      sessionStorage.setItem(EXP_KEY, expiresAt);
+      setState({ token, username, credentialsBlob, expiresAt });
+    },
+    [],
+  );
+
+  const logout = useCallback(() => {
+    sessionStorage.removeItem(TOKEN_KEY);
+    sessionStorage.removeItem(USER_KEY);
+    sessionStorage.removeItem(EXP_KEY);
+    setState({ token: null, username: null, credentialsBlob: null, expiresAt: null });
+  }, []);
+
+  const setCredentialsBlob = useCallback((blob: string) => {
+    setState((s) => ({ ...s, credentialsBlob: blob }));
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ ...state, login, logout, setCredentialsBlob }),
+    [state, login, logout, setCredentialsBlob],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+```
+
+- [ ] **Step 4: Create `web/src/auth/useAuth.ts`**
+
+```ts
+import { useContext } from 'react';
+import { AuthContext, type AuthContextValue } from './AuthProvider';
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}
+```
+
+- [ ] **Step 5: Run AuthProvider tests, verify pass**
+
+```bash
+cd web && npm test -- src/auth/AuthProvider.test
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Write failing test for `ProtectedRoute`**
+
+`web/src/auth/ProtectedRoute.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from './AuthProvider';
+import { ProtectedRoute } from './ProtectedRoute';
+
+function setup(route: string, token: string | null) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthProvider initial={{ token }}>
+        <Routes>
+          <Route path="/login" element={<div>LOGIN</div>} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/secret" element={<div>SECRET</div>} />
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProtectedRoute', () => {
+  it('renders children when authed', () => {
+    setup('/secret', 'tok');
+    expect(screen.getByText('SECRET')).toBeInTheDocument();
+  });
+  it('redirects to /login when no token', () => {
+    setup('/secret', null);
+    expect(screen.getByText('LOGIN')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 7: Create `web/src/auth/ProtectedRoute.tsx`**
+
+```tsx
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+export function ProtectedRoute() {
+  const { token } = useAuth();
+  const location = useLocation();
+  if (!token) return <Navigate to="/login" replace state={{ from: location }} />;
+  return <Outlet />;
+}
+```
+
+- [ ] **Step 8: Run, verify pass**
+
+```bash
+cd web && npm test -- src/auth/
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/auth/
+git commit -m "feat(web): AuthProvider + ProtectedRoute"
+```
+
+---
+
+## Task 6: Format helpers + Zod schemas
+
+**Files:**
+- Create: `web/src/lib/format.ts`, `web/src/lib/schemas.ts`
+- Test: `web/src/lib/format.test.ts`, `web/src/lib/schemas.test.ts`
+
+- [ ] **Step 1: Failing test for `format.ts`**
+
+`web/src/lib/format.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { formatTargetDate, formatDayOfWeek, formatLastAttempt } from './format';
+
+describe('format helpers', () => {
+  it('formats a target date as "Sat 24 May"', () => {
+    expect(formatTargetDate('2026-05-23')).toMatch(/^Sat\b.+May$/);
+  });
+
+  it('formats day_of_week with Monday=0', () => {
+    expect(formatDayOfWeek(0)).toBe('Every Monday');
+    expect(formatDayOfWeek(6)).toBe('Every Sunday');
+  });
+
+  it('returns "No attempts yet" for empty array', () => {
+    expect(formatLastAttempt([])).toBe('No attempts yet');
+  });
+
+  it('summarises the most recent attempt', () => {
+    const a = [
+      { ts: '2026-05-19T10:00:00Z', target_date: '2026-05-20',
+        outcome: 'no_slots' as const, booking_id: null, error: null },
+      { ts: '2026-05-19T12:00:00Z', target_date: '2026-05-20',
+        outcome: 'booked' as const, booking_id: 'B1', error: null },
+    ];
+    expect(formatLastAttempt(a)).toMatch(/booked/);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `web/src/lib/format.ts`**
+
+```ts
+import type { Attempt } from '../api/types';
+
+const DAYS = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+const SHORT_DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+export function formatTargetDate(iso: string): string {
+  // Treat as a local calendar date (no TZ shifting).
+  const [y, m, d] = iso.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  // JS getDay(): 0=Sun..6=Sat. Map to our Mon=0 ordering for short day lookup.
+  const jsDow = date.getDay();
+  const shortIdx = jsDow === 0 ? 6 : jsDow - 1;
+  return `${SHORT_DAYS[shortIdx]} ${d} ${MONTHS[m - 1]}`;
+}
+
+export function formatDayOfWeek(dow: number): string {
+  return `Every ${DAYS[dow] ?? '?'}`;
+}
+
+export function formatLastAttempt(attempts: Attempt[]): string {
+  if (attempts.length === 0) return 'No attempts yet';
+  const last = [...attempts].sort((a, b) => (a.ts < b.ts ? 1 : -1))[0];
+  return `${relTime(last.ts)} · ${last.outcome}`;
+}
+
+function relTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+```bash
+cd web && npm test -- src/lib/format
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 4: Failing test for Zod schemas**
+
+`web/src/lib/schemas.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { oneShotSchema, recurringSchema, loginSchema } from './schemas';
+
+describe('schemas', () => {
+  it('login requires non-empty username + pin', () => {
+    expect(loginSchema.safeParse({ username: '', pin: 'x' }).success).toBe(false);
+    expect(loginSchema.safeParse({ username: 'u', pin: 'p' }).success).toBe(true);
+  });
+
+  it('one-shot rejects end_time <= start_time', () => {
+    const base = { target_date: '2026-05-25', start_time: '14:00', end_time: '14:00',
+                   num_slots: 1, partners: [] };
+    expect(oneShotSchema.safeParse(base).success).toBe(false);
+  });
+
+  it('one-shot accepts a valid window', () => {
+    expect(oneShotSchema.safeParse({
+      target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+      num_slots: 1, partners: [],
+    }).success).toBe(true);
+  });
+
+  it('partners max length 3', () => {
+    const base = { target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+                   num_slots: 1, partners: ['a','b','c','d'] };
+    expect(oneShotSchema.safeParse(base).success).toBe(false);
+  });
+
+  it('recurring requires day_of_week 0..6', () => {
+    const ok = { day_of_week: 0, start_time: '09:00', end_time: '11:00',
+                 num_slots: 2, partners: [] };
+    expect(recurringSchema.safeParse(ok).success).toBe(true);
+    expect(recurringSchema.safeParse({ ...ok, day_of_week: 7 }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5: Implement `web/src/lib/schemas.ts`**
+
+```ts
+import { z } from 'zod';
+
+const HHMM = /^\d{2}:\d{2}$/;
+const YMD  = /^\d{4}-\d{2}-\d{2}$/;
+const E164 = /^\+[1-9]\d{1,14}$/;
+
+export const loginSchema = z.object({
+  username: z.string().min(1, 'Username required'),
+  pin:      z.string().min(1, 'PIN required'),
+});
+
+const notifySchema = z.object({
+  to:   z.string().regex(E164, 'Must be E.164, e.g. +14155551212'),
+  from: z.string().regex(E164).optional().or(z.literal('').transform(() => undefined)),
+}).optional();
+
+const commonShape = {
+  start_time: z.string().regex(HHMM),
+  end_time:   z.string().regex(HHMM),
+  num_slots:  z.number().int().min(1).max(4),
+  partners:   z.array(z.string()).max(3),
+  notify:     notifySchema,
+};
+
+function refineWindow<T extends { start_time: string; end_time: string }>(s: z.ZodType<T>) {
+  return s.refine((v) => v.end_time > v.start_time, {
+    message: 'End time must be after start time', path: ['end_time'],
+  });
+}
+
+export const oneShotSchema = refineWindow(
+  z.object({ target_date: z.string().regex(YMD), ...commonShape }),
+);
+
+export const recurringSchema = refineWindow(
+  z.object({
+    day_of_week: z.number().int().min(0).max(6),
+    end_date: z.string().regex(YMD).optional().or(z.literal('').transform(() => undefined)),
+    ...commonShape,
+  }),
+);
+
+export const patchSchema = z.object({
+  start_time: z.string().regex(HHMM).optional(),
+  end_time:   z.string().regex(HHMM).optional(),
+  num_slots:  z.number().int().min(1).max(4).optional(),
+  partners:   z.array(z.string()).max(3).optional(),
+  notify:     notifySchema,
+});
+
+export type LoginForm     = z.infer<typeof loginSchema>;
+export type OneShotForm   = z.infer<typeof oneShotSchema>;
+export type RecurringForm = z.infer<typeof recurringSchema>;
+```
+
+- [ ] **Step 6: Run, verify pass**
+
+```bash
+cd web && npm test -- src/lib/
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/
+git commit -m "feat(web): format helpers + Zod schemas"
+```
+
+---
+
+## Task 7: Data hooks (React Query)
+
+**Files:**
+- Create: `web/src/hooks/useWanted.ts`, `web/src/hooks/usePartners.ts`, `web/src/hooks/useLogin.ts`
+
+This task is plain glue; tests live in the consuming page tests rather than per-hook. Hooks are written without TDD here — adding a test per hook would be ceremony with no extra coverage.
+
+- [ ] **Step 1: Create `web/src/hooks/useWanted.ts`**
+
+```ts
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createWanted, deleteWanted, getWanted, listWanted, patchWanted,
+} from '../api/endpoints';
+import type {
+  CreateOneShotRequest, CreateRecurringRequest, PatchWantedRequest, WantedKind,
+} from '../api/types';
+import { useAuth } from '../auth/useAuth';
+
+export function useWantedList() {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['wanted'],
+    queryFn: () => listWanted(token!),
+    enabled: !!token,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useWanted(id: string) {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['wanted', id],
+    queryFn: () => getWanted(token!, id),
+    enabled: !!token,
+  });
+}
+
+export function useCreateWanted() {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: {
+      kind: WantedKind;
+      body: CreateOneShotRequest | CreateRecurringRequest;
+    }) => createWanted(token!, vars.kind, vars.body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['wanted'] }),
+  });
+}
+
+export function usePatchWanted(id: string) {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PatchWantedRequest) => patchWanted(token!, id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['wanted'] });
+      qc.invalidateQueries({ queryKey: ['wanted', id] });
+    },
+  });
+}
+
+export function useDeleteWanted() {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteWanted(token!, id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['wanted'] }),
+  });
+}
+```
+
+- [ ] **Step 2: Create `web/src/hooks/usePartners.ts`**
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { listPartners } from '../api/endpoints';
+import { useAuth } from '../auth/useAuth';
+
+export function usePartners() {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['partners'],
+    queryFn: () => listPartners(token!).then((r) => r.partners),
+    enabled: !!token,
+    staleTime: 5 * 60_000,
+  });
+}
+```
+
+- [ ] **Step 3: Create `web/src/hooks/useLogin.ts`**
+
+```ts
+import { useMutation } from '@tanstack/react-query';
+import { encryptCredentials, login } from '../api/endpoints';
+import { useAuth } from '../auth/useAuth';
+
+export function useLogin() {
+  const auth = useAuth();
+  return useMutation({
+    mutationFn: async (vars: { username: string; pin: string }) => {
+      const { credentials } = await encryptCredentials(vars);
+      const { access_token, expires_at } = await login({ credentials });
+      auth.login(access_token, vars.username, credentials, expires_at);
+      return { access_token };
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd web && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/hooks/
+git commit -m "feat(web): data hooks (useWanted, usePartners, useLogin)"
+```
+
+---
+
+## Task 8: UI primitives — StatusPill, ConfirmDialog, AttemptList
+
+**Files:**
+- Create: `web/src/components/StatusPill.tsx`, `web/src/components/ConfirmDialog.tsx`, `web/src/components/AttemptList.tsx`
+- Test: `web/src/components/StatusPill.test.tsx`, `web/src/components/AttemptList.test.tsx`
+
+- [ ] **Step 1: Failing test for `StatusPill`**
+
+`web/src/components/StatusPill.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatusPill } from './StatusPill';
+
+describe('StatusPill', () => {
+  it.each(['pending','booked','expired','disabled'] as const)('renders %s', (s) => {
+    render(<StatusPill status={s} />);
+    expect(screen.getByText(s.toUpperCase())).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `web/src/components/StatusPill.tsx`**
+
+```tsx
+import type { WantedStatus } from '../api/types';
+
+const COLORS: Record<WantedStatus, string> = {
+  pending:  'bg-blue-600 text-white',
+  booked:   'bg-green-600 text-white',
+  expired:  'bg-amber-600 text-white',
+  disabled: 'bg-slate-600 text-slate-200',
+};
+
+export function StatusPill({ status }: { status: WantedStatus }) {
+  return (
+    <span className={`text-[11px] px-2 py-0.5 rounded-full ${COLORS[status]}`}>
+      {status.toUpperCase()}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `web/src/components/ConfirmDialog.tsx`**
+
+```tsx
+import type { ReactNode } from 'react';
+
+export function ConfirmDialog({
+  open, title, body, confirmLabel = 'Confirm', onConfirm, onCancel,
+}: {
+  open: boolean;
+  title: string;
+  body?: ReactNode;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+         role="dialog" aria-modal="true">
+      <div className="bg-slate-900 border border-slate-700 rounded-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        {body && <div className="text-slate-300 mb-4">{body}</div>}
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded bg-slate-700">
+            Cancel
+          </button>
+          <button onClick={onConfirm} className="px-3 py-1.5 rounded bg-red-600 text-white">
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Failing test for `AttemptList`**
+
+`web/src/components/AttemptList.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AttemptList } from './AttemptList';
+
+describe('AttemptList', () => {
+  it('shows empty state', () => {
+    render(<AttemptList attempts={[]} />);
+    expect(screen.getByText('No attempts yet.')).toBeInTheDocument();
+  });
+
+  it('renders newest first with outcome + error', () => {
+    render(<AttemptList attempts={[
+      { ts: '2026-05-19T10:00:00Z', target_date: '2026-05-20',
+        outcome: 'no_slots', booking_id: null, error: null },
+      { ts: '2026-05-19T12:00:00Z', target_date: '2026-05-20',
+        outcome: 'booking_failed', booking_id: null, error: 'partner unknown' },
+    ]} />);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[0]).toHaveTextContent('booking_failed');
+    expect(rows[0]).toHaveTextContent('partner unknown');
+  });
+});
+```
+
+- [ ] **Step 5: Implement `web/src/components/AttemptList.tsx`**
+
+```tsx
+import type { Attempt } from '../api/types';
+
+export function AttemptList({ attempts }: { attempts: Attempt[] }) {
+  if (attempts.length === 0) {
+    return <p className="text-slate-400">No attempts yet.</p>;
+  }
+  const sorted = [...attempts].sort((a, b) => (a.ts < b.ts ? 1 : -1));
+  return (
+    <ul className="space-y-2">
+      {sorted.map((a, i) => (
+        <li key={i} className="border border-slate-800 rounded p-3">
+          <div className="flex justify-between text-sm">
+            <span>{new Date(a.ts).toLocaleString()}</span>
+            <span className="font-mono">{a.outcome}</span>
+          </div>
+          {a.booking_id && (
+            <div className="text-xs text-slate-400">booking: {a.booking_id}</div>
+          )}
+          {a.error && (
+            <div className="text-xs text-red-400 mt-1">{a.error}</div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **Step 6: Run all component tests**
+
+```bash
+cd web && npm test -- src/components/
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/
+git commit -m "feat(web): StatusPill, ConfirmDialog, AttemptList"
+```
+
+---
+
+## Task 9: PartnerPicker + NotifyFields + SlotFormFields
+
+**Files:**
+- Create: `web/src/components/PartnerPicker.tsx`, `web/src/components/NotifyFields.tsx`, `web/src/components/SlotFormFields.tsx`
+- Test: `web/src/components/PartnerPicker.test.tsx`
+
+- [ ] **Step 1: Failing test for `PartnerPicker`**
+
+`web/src/components/PartnerPicker.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { PartnerPicker } from './PartnerPicker';
+import { AuthProvider } from '../auth/AuthProvider';
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AuthProvider initial={{ token: 'tok' }}>{ui}</AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PartnerPicker', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('lists partners and toggles selection up to 3', async () => {
+    server.use(http.get(`${baseUrl}/api/partners`, () =>
+      HttpResponse.json({ partners: [
+        { id: 'a', name: 'Alice' },
+        { id: 'b', name: 'Bob' },
+        { id: 'c', name: 'Carol' },
+        { id: 'd', name: 'Dave' },
+      ]}),
+    ));
+    const onChange = vi.fn();
+    wrap(<PartnerPicker value={[]} onChange={onChange} />);
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Alice'));
+    expect(onChange).toHaveBeenLastCalledWith(['a']);
+  });
+
+  it('disables remaining checkboxes once 3 selected', async () => {
+    server.use(http.get(`${baseUrl}/api/partners`, () =>
+      HttpResponse.json({ partners: [
+        { id: 'a', name: 'A' }, { id: 'b', name: 'B' },
+        { id: 'c', name: 'C' }, { id: 'd', name: 'D' },
+      ]}),
+    ));
+    wrap(<PartnerPicker value={['a','b','c']} onChange={() => {}} />);
+    expect((await screen.findByLabelText('D'))).toBeDisabled();
+    expect(screen.getByLabelText('A')).not.toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `web/src/components/PartnerPicker.tsx`**
+
+```tsx
+import { usePartners } from '../hooks/usePartners';
+
+export function PartnerPicker({
+  value, onChange,
+}: { value: string[]; onChange: (next: string[]) => void }) {
+  const { data: partners = [], isLoading } = usePartners();
+  const atCap = value.length >= 3;
+
+  function toggle(id: string) {
+    if (value.includes(id)) onChange(value.filter((x) => x !== id));
+    else if (!atCap) onChange([...value, id]);
+  }
+
+  if (isLoading) return <p className="text-slate-400">Loading partners…</p>;
+  if (partners.length === 0) {
+    return <p className="text-slate-400 text-sm">No partners configured.</p>;
+  }
+  return (
+    <fieldset className="grid grid-cols-2 gap-2">
+      <legend className="text-sm text-slate-300 mb-1">Partners (max 3)</legend>
+      {partners.map((p) => {
+        const checked = value.includes(p.id);
+        return (
+          <label key={p.id} className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              aria-label={p.name}
+              checked={checked}
+              disabled={!checked && atCap}
+              onChange={() => toggle(p.id)}
+            />
+            {p.name}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `web/src/components/NotifyFields.tsx`**
+
+```tsx
+import type { UseFormRegister, FieldErrors } from 'react-hook-form';
+
+export function NotifyFields({
+  register, errors,
+}: { register: UseFormRegister<any>; errors: FieldErrors<any> }) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm text-slate-300">Notify (optional)</legend>
+      <div>
+        <label className="text-xs text-slate-400" htmlFor="notify-to">To (E.164)</label>
+        <input id="notify-to" {...register('notify.to')}
+               placeholder="+14155551212"
+               className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        {errors.notify && (errors.notify as any).to && (
+          <p className="text-xs text-red-400">{(errors.notify as any).to.message}</p>
+        )}
+      </div>
+      <div>
+        <label className="text-xs text-slate-400" htmlFor="notify-from">From (optional)</label>
+        <input id="notify-from" {...register('notify.from')}
+               className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+      </div>
+    </fieldset>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `web/src/components/SlotFormFields.tsx`** (shared fields used by both forms)
+
+```tsx
+import { Controller, type Control, type UseFormRegister, type FieldErrors } from 'react-hook-form';
+import { PartnerPicker } from './PartnerPicker';
+import { NotifyFields } from './NotifyFields';
+
+export function SlotFormFields({
+  register, control, errors,
+}: {
+  register: UseFormRegister<any>;
+  control: Control<any>;
+  errors: FieldErrors<any>;
+}) {
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="text-sm">Start
+          <input type="time" step={60} {...register('start_time')}
+                 className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        </label>
+        <label className="text-sm">End
+          <input type="time" step={60} {...register('end_time')}
+                 className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+          {errors.end_time && (
+            <p className="text-xs text-red-400">{String(errors.end_time.message)}</p>
+          )}
+        </label>
+      </div>
+
+      <label className="text-sm block">Slots
+        <select {...register('num_slots', { valueAsNumber: true })}
+                className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+          <option value={1}>1</option><option value={2}>2</option>
+          <option value={3}>3</option><option value={4}>4</option>
+        </select>
+      </label>
+
+      <Controller
+        control={control}
+        name="partners"
+        render={({ field }) => (
+          <PartnerPicker value={field.value ?? []} onChange={field.onChange} />
+        )}
+      />
+
+      <NotifyFields register={register} errors={errors} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd web && npm test -- src/components/PartnerPicker
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/
+git commit -m "feat(web): PartnerPicker, NotifyFields, SlotFormFields"
+```
+
+---
+
+## Task 10: WantedCard
+
+**Files:**
+- Create: `web/src/components/WantedCard.tsx`
+- Test: `web/src/components/WantedCard.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { WantedCard } from './WantedCard';
+import type { WantedResponse } from '../api/types';
+
+const base: WantedResponse = {
+  id: 'abc', kind: 'one_shot',
+  target_date: '2026-05-23', day_of_week: null, end_date: null,
+  start_time: '14:00', end_time: '16:30',
+  num_slots: 4, partners: ['p1','p2'],
+  has_credentials: true, notify: null,
+  status: 'pending', attempts: [],
+  created_at: '2026-05-19T00:00:00Z', updated_at: '2026-05-19T00:00:00Z',
+};
+
+describe('WantedCard', () => {
+  it('renders one_shot title from target_date', () => {
+    render(<MemoryRouter><WantedCard slot={base} /></MemoryRouter>);
+    expect(screen.getByText(/Sat\b.+May/)).toBeInTheDocument();
+    expect(screen.getByText('14:00–16:30 · 4 slots · 2 partners')).toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+    expect(screen.getByText('No attempts yet')).toBeInTheDocument();
+  });
+
+  it('renders recurring title from day_of_week', () => {
+    render(<MemoryRouter><WantedCard slot={{
+      ...base, kind: 'recurring', target_date: null, day_of_week: 6,
+    }} /></MemoryRouter>);
+    expect(screen.getByText('Every Sunday')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `WantedCard.tsx`**
+
+```tsx
+import { Link } from 'react-router-dom';
+import type { WantedResponse } from '../api/types';
+import { StatusPill } from './StatusPill';
+import { formatDayOfWeek, formatLastAttempt, formatTargetDate } from '../lib/format';
+
+export function WantedCard({ slot }: { slot: WantedResponse }) {
+  const title =
+    slot.kind === 'one_shot' && slot.target_date
+      ? formatTargetDate(slot.target_date)
+      : slot.day_of_week != null
+        ? formatDayOfWeek(slot.day_of_week)
+        : '—';
+
+  return (
+    <Link to={`/wanted/${slot.id}`}
+          className={`block border border-slate-700 rounded-lg p-3 hover:border-slate-500
+                      ${slot.status === 'disabled' ? 'opacity-60' : ''}`}>
+      <div className="flex justify-between items-start">
+        <strong>{title}</strong>
+        <StatusPill status={slot.status} />
+      </div>
+      <div className="text-sm text-slate-300 mt-1">
+        {slot.start_time}–{slot.end_time} · {slot.num_slots} slots
+        {slot.partners.length > 0 && ` · ${slot.partners.length} partners`}
+      </div>
+      <div className="text-xs text-slate-400 mt-1">{formatLastAttempt(slot.attempts)}</div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+```bash
+cd web && npm test -- src/components/WantedCard
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/WantedCard.*
+git commit -m "feat(web): WantedCard"
+```
+
+---
+
+## Task 11: LoginPage
+
+**Files:**
+- Create: `web/src/pages/LoginPage.tsx`
+- Test: `web/src/pages/LoginPage.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { LoginPage } from './LoginPage';
+import { Route, Routes } from 'react-router-dom';
+
+describe('LoginPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('logs in and navigates to /wanted', async () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/login' },
+    );
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice');
+    await userEvent.type(screen.getByLabelText(/pin/i), '1234');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+    expect(sessionStorage.getItem('tsa.token')).toBe('test-token');
+  });
+
+  it('shows "Invalid username or PIN" on 401', async () => {
+    server.use(http.post(`${baseUrl}/api/login`, () =>
+      HttpResponse.json({ detail: 'bad creds' }, { status: 401 }),
+    ));
+    renderWithProviders(<LoginPage />, { route: '/login' });
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice');
+    await userEvent.type(screen.getByLabelText(/pin/i), 'x');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(await screen.findByText(/Invalid username or PIN/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `LoginPage.tsx`**
+
+```tsx
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { ApiError } from '../api/client';
+import { useLogin } from '../hooks/useLogin';
+import { loginSchema, type LoginForm } from '../lib/schemas';
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const m = useLogin();
+  const { register, handleSubmit, formState: { errors } } = useForm<LoginForm>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await m.mutateAsync(values);
+    navigate('/wanted');
+  });
+
+  const errorMsg =
+    m.error instanceof ApiError
+      ? m.error.status === 401 ? 'Invalid username or PIN.'
+      : m.error.status === 502 ? 'Booking site unreachable; try again shortly.'
+      : `Login failed: ${m.error.detail}`
+      : null;
+
+  return (
+    <main className="min-h-screen grid place-items-center">
+      <form onSubmit={onSubmit}
+            className="w-full max-w-sm bg-slate-900 p-6 rounded-lg border border-slate-700 space-y-3">
+        <h1 className="text-xl font-semibold">Sign in</h1>
+        <label className="block text-sm">Username
+          <input {...register('username')} autoComplete="username"
+                 className="block w-full bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+          {errors.username && <p className="text-xs text-red-400">{errors.username.message}</p>}
+        </label>
+        <label className="block text-sm">PIN
+          <input type="password" {...register('pin')} autoComplete="current-password"
+                 className="block w-full bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+          {errors.pin && <p className="text-xs text-red-400">{errors.pin.message}</p>}
+        </label>
+        {errorMsg && <p className="text-sm text-red-400">{errorMsg}</p>}
+        <button type="submit" disabled={m.isPending}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50
+                           text-white rounded px-3 py-2">
+          {m.isPending ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+```bash
+cd web && npm test -- src/pages/LoginPage
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/pages/LoginPage.*
+git commit -m "feat(web): LoginPage"
+```
+
+---
+
+## Task 12: WantedListPage
+
+**Files:**
+- Create: `web/src/pages/WantedListPage.tsx`
+- Test: `web/src/pages/WantedListPage.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedListPage } from './WantedListPage';
+import type { WantedResponse } from '../api/types';
+
+const fixtures: WantedResponse[] = [
+  { id: '1', kind: 'one_shot', target_date: '2026-05-23',
+    day_of_week: null, end_date: null,
+    start_time: '14:00', end_time: '16:30', num_slots: 4, partners: [],
+    has_credentials: true, notify: null, status: 'pending', attempts: [],
+    created_at: '', updated_at: '' },
+  { id: '2', kind: 'recurring', target_date: null, day_of_week: 0, end_date: null,
+    start_time: '09:00', end_time: '11:00', num_slots: 2, partners: [],
+    has_credentials: true, notify: null, status: 'disabled', attempts: [],
+    created_at: '', updated_at: '' },
+];
+
+describe('WantedListPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('lists cards and filters by status', async () => {
+    server.use(http.get(`${baseUrl}/api/wanted`, () => HttpResponse.json(fixtures)));
+    renderWithProviders(<WantedListPage />, { initialAuth: { token: 'tok', username: 'alice' } });
+
+    expect(await screen.findByText(/Sat\b.+May/)).toBeInTheDocument();
+    expect(screen.getByText('Every Monday')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^Disabled$/ }));
+    expect(screen.queryByText(/Sat\b.+May/)).not.toBeInTheDocument();
+    expect(screen.getByText('Every Monday')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `WantedListPage.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth/useAuth';
+import { useWantedList } from '../hooks/useWanted';
+import { WantedCard } from '../components/WantedCard';
+import type { WantedStatus } from '../api/types';
+
+type Filter = 'all' | WantedStatus;
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'pending', label: 'Pending' },
+  { key: 'booked', label: 'Booked' },
+  { key: 'disabled', label: 'Disabled' },
+  { key: 'expired', label: 'Expired' },
+];
+
+export function WantedListPage() {
+  const auth = useAuth();
+  const { data: slots, isLoading, error } = useWantedList();
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered = (slots ?? []).filter((s) => filter === 'all' ? true : s.status === filter);
+
+  return (
+    <main className="max-w-5xl mx-auto p-6">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Wanted tee-times</h1>
+        <div className="flex items-center gap-3 text-sm">
+          <Link to="/wanted/new"
+                className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
+            + New
+          </Link>
+          <span className="text-slate-400">Logged in as {auth.username}</span>
+          <button onClick={() => auth.logout()} className="text-slate-300 underline">Logout</button>
+        </div>
+      </header>
+
+      <div className="flex gap-2 mb-4">
+        {FILTERS.map((f) => (
+          <button key={f.key}
+                  onClick={() => setFilter(f.key)}
+                  className={`text-sm px-3 py-1 rounded-full border
+                              ${filter === f.key
+                                ? 'bg-slate-700 border-slate-500'
+                                : 'border-slate-700 hover:border-slate-500'}`}>
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-slate-400">Loading…</p>}
+      {error && <p className="text-red-400">Failed to load wanted slots.</p>}
+      {!isLoading && filtered.length === 0 && (
+        <p className="text-slate-400">No wanted slots match this filter.</p>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((s) => <WantedCard key={s.id} slot={s} />)}
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+```bash
+cd web && npm test -- src/pages/WantedListPage
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/pages/WantedListPage.*
+git commit -m "feat(web): WantedListPage"
+```
+
+---
+
+## Task 13: WantedNewPage (OneShotForm + RecurringForm)
+
+**Files:**
+- Create: `web/src/components/OneShotForm.tsx`, `web/src/components/RecurringForm.tsx`, `web/src/pages/WantedNewPage.tsx`
+- Test: `web/src/pages/WantedNewPage.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedNewPage } from './WantedNewPage';
+import { Route, Routes } from 'react-router-dom';
+
+describe('WantedNewPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('submits a one-shot wanted slot and navigates back to /wanted', async () => {
+    let received: { url: string; body: any } | null = null;
+    server.use(http.post(`${baseUrl}/api/wanted`, async ({ request }) => {
+      received = { url: request.url, body: await request.json() };
+      return HttpResponse.json({ id: 'new' }, { status: 201 });
+    }));
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/new" element={<WantedNewPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      {
+        route: '/wanted/new',
+        initialAuth: { token: 'tok', credentialsBlob: 'BLOB' },
+      },
+    );
+
+    await userEvent.type(screen.getByLabelText(/target date/i), '2026-05-25');
+    await userEvent.clear(screen.getByLabelText(/^start$/i));
+    await userEvent.type(screen.getByLabelText(/^start$/i), '14:00');
+    await userEvent.clear(screen.getByLabelText(/^end$/i));
+    await userEvent.type(screen.getByLabelText(/^end$/i), '16:00');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+    expect(received!.url).toContain('kind=one_shot');
+    expect(received!.body.credentials).toBe('BLOB');
+    expect(received!.body.target_date).toBe('2026-05-25');
+  });
+
+  it('toggles to Recurring mode', async () => {
+    renderWithProviders(<WantedNewPage />, {
+      route: '/wanted/new',
+      initialAuth: { token: 'tok', credentialsBlob: 'BLOB' },
+    });
+    await userEvent.click(screen.getByRole('tab', { name: /recurring/i }));
+    expect(screen.getByLabelText(/day of week/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `OneShotForm.tsx`**
+
+```tsx
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { SlotFormFields } from './SlotFormFields';
+import { oneShotSchema, type OneShotForm as OneShotValues } from '../lib/schemas';
+
+export interface OneShotSubmit extends OneShotValues {}
+
+const today = new Date().toISOString().slice(0, 10);
+const plus7 = new Date(Date.now() + 7 * 86400_000).toISOString().slice(0, 10);
+
+export function OneShotForm({ onSubmit, busy }: {
+  onSubmit: (v: OneShotSubmit) => void; busy: boolean;
+}) {
+  const { register, handleSubmit, control, formState: { errors } } = useForm<OneShotValues>({
+    resolver: zodResolver(oneShotSchema),
+    defaultValues: { num_slots: 1, partners: [] },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <label className="text-sm block">Target date
+        <input type="date" min={today} max={plus7}
+               {...register('target_date')}
+               className="block bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        {errors.target_date && (
+          <p className="text-xs text-red-400">{errors.target_date.message}</p>
+        )}
+      </label>
+      <SlotFormFields register={register} control={control} errors={errors} />
+      <button type="submit" disabled={busy}
+              className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-2 disabled:opacity-50">
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `RecurringForm.tsx`**
+
+```tsx
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { SlotFormFields } from './SlotFormFields';
+import { recurringSchema, type RecurringForm as RecurringValues } from '../lib/schemas';
+
+const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+
+export function RecurringForm({ onSubmit, busy }: {
+  onSubmit: (v: RecurringValues) => void; busy: boolean;
+}) {
+  const { register, handleSubmit, control, formState: { errors } } = useForm<RecurringValues>({
+    resolver: zodResolver(recurringSchema),
+    defaultValues: { num_slots: 1, partners: [], day_of_week: 0 },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <label className="text-sm block">Day of week
+        <select {...register('day_of_week', { valueAsNumber: true })}
+                className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+          {DAYS.map((d, i) => <option key={i} value={i}>{d}</option>)}
+        </select>
+      </label>
+      <label className="text-sm block">End date (optional)
+        <input type="date" {...register('end_date')}
+               className="block bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+      </label>
+      <SlotFormFields register={register} control={control} errors={errors} />
+      <button type="submit" disabled={busy}
+              className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-2 disabled:opacity-50">
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `WantedNewPage.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ApiError } from '../api/client';
+import { useAuth } from '../auth/useAuth';
+import { useCreateWanted } from '../hooks/useWanted';
+import { OneShotForm } from '../components/OneShotForm';
+import { RecurringForm } from '../components/RecurringForm';
+import { encryptCredentials } from '../api/endpoints';
+
+type Mode = 'one_shot' | 'recurring';
+
+export function WantedNewPage() {
+  const [mode, setMode] = useState<Mode>('one_shot');
+  const [pinPrompt, setPinPrompt] = useState<{ user: string; pin: string }>({ user: '', pin: '' });
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const m = useCreateWanted();
+
+  async function obtainBlob(): Promise<string> {
+    if (auth.credentialsBlob) return auth.credentialsBlob;
+    if (!auth.username) throw new Error('Not authenticated');
+    if (!pinPrompt.pin) throw new Error('Re-enter PIN to save');
+    const { credentials } = await encryptCredentials({
+      username: auth.username, pin: pinPrompt.pin,
+    });
+    auth.setCredentialsBlob(credentials);
+    return credentials;
+  }
+
+  async function submit(values: any) {
+    try {
+      const credentials = await obtainBlob();
+      await m.mutateAsync({ kind: mode, body: { ...values, credentials } });
+      toast.success('Wanted slot created');
+      navigate('/wanted');
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.detail : (e as Error).message;
+      toast.error(msg);
+    }
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">New wanted slot</h1>
+      <div role="tablist" className="inline-flex bg-slate-900 rounded p-1 mb-4">
+        <button role="tab" aria-selected={mode === 'one_shot'}
+                onClick={() => setMode('one_shot')}
+                className={`px-3 py-1 rounded ${mode === 'one_shot' ? 'bg-slate-700' : ''}`}>
+          One-shot
+        </button>
+        <button role="tab" aria-selected={mode === 'recurring'}
+                onClick={() => setMode('recurring')}
+                className={`px-3 py-1 rounded ${mode === 'recurring' ? 'bg-slate-700' : ''}`}>
+          Recurring
+        </button>
+      </div>
+
+      {!auth.credentialsBlob && (
+        <div className="mb-4 border border-amber-700/50 bg-amber-900/20 rounded p-3 text-sm">
+          <p className="mb-2">Re-enter your PIN to save credentials to this slot.</p>
+          <input type="password" placeholder="PIN"
+                 value={pinPrompt.pin}
+                 onChange={(e) => setPinPrompt({ user: auth.username ?? '', pin: e.target.value })}
+                 className="bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+        </div>
+      )}
+
+      {mode === 'one_shot'
+        ? <OneShotForm onSubmit={submit} busy={m.isPending} />
+        : <RecurringForm onSubmit={submit} busy={m.isPending} />}
+    </main>
+  );
+}
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd web && npm test -- src/pages/WantedNewPage
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/WantedNewPage.* web/src/components/OneShotForm.* web/src/components/RecurringForm.*
+git commit -m "feat(web): WantedNewPage with one-shot + recurring forms"
+```
+
+---
+
+## Task 14: WantedDetailPage
+
+**Files:**
+- Create: `web/src/pages/WantedDetailPage.tsx`
+- Test: `web/src/pages/WantedDetailPage.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedDetailPage } from './WantedDetailPage';
+import { Route, Routes } from 'react-router-dom';
+import type { WantedResponse } from '../api/types';
+
+const slot: WantedResponse = {
+  id: 'abc', kind: 'one_shot', target_date: '2026-05-23',
+  day_of_week: null, end_date: null,
+  start_time: '14:00', end_time: '16:30', num_slots: 4, partners: [],
+  has_credentials: true, notify: null, status: 'pending',
+  attempts: [{ ts: '2026-05-19T10:00:00Z', target_date: '2026-05-23',
+               outcome: 'no_slots', booking_id: null, error: null }],
+  created_at: '', updated_at: '',
+};
+
+describe('WantedDetailPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('shows attempts and supports delete', async () => {
+    server.use(
+      http.get(`${baseUrl}/api/wanted/abc`, () => HttpResponse.json(slot)),
+      http.delete(`${baseUrl}/api/wanted/abc`, () =>
+        new HttpResponse(null, { status: 204 }),
+      ),
+    );
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/:id" element={<WantedDetailPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/wanted/abc', initialAuth: { token: 'tok' } },
+    );
+    expect(await screen.findByText('no_slots')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Implement `WantedDetailPage.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ApiError } from '../api/client';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { AttemptList } from '../components/AttemptList';
+import { StatusPill } from '../components/StatusPill';
+import { useDeleteWanted, usePatchWanted, useWanted } from '../hooks/useWanted';
+
+export function WantedDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const { data: slot, isLoading } = useWanted(id);
+  const patch = usePatchWanted(id);
+  const del = useDeleteWanted();
+  const [confirming, setConfirming] = useState(false);
+  const [form, setForm] = useState({ start_time: '', end_time: '', num_slots: 1 });
+
+  if (isLoading || !slot) return <main className="p-6 text-slate-400">Loading…</main>;
+
+  // Initialise form from slot the first time it loads.
+  if (form.start_time === '') {
+    setForm({ start_time: slot.start_time, end_time: slot.end_time, num_slots: slot.num_slots });
+  }
+
+  async function save() {
+    try { await patch.mutateAsync(form); toast.success('Saved'); }
+    catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  async function toggleDisabled() {
+    try {
+      await patch.mutateAsync({ disabled: slot.status !== 'disabled' });
+    } catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  async function confirmDelete() {
+    try {
+      await del.mutateAsync(slot.id);
+      toast.success('Deleted');
+      navigate('/wanted');
+    } catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  return (
+    <main className="max-w-5xl mx-auto p-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h1 className="text-xl font-semibold">Edit</h1>
+          <StatusPill status={slot.status} />
+        </div>
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm">Start
+              <input type="time" value={form.start_time}
+                     onChange={(e) => setForm({ ...form, start_time: e.target.value })}
+                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+            </label>
+            <label className="text-sm">End
+              <input type="time" value={form.end_time}
+                     onChange={(e) => setForm({ ...form, end_time: e.target.value })}
+                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+            </label>
+          </div>
+          <label className="text-sm block">Slots
+            <select value={form.num_slots}
+                    onChange={(e) => setForm({ ...form, num_slots: Number(e.target.value) })}
+                    className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+              <option value={1}>1</option><option value={2}>2</option>
+              <option value={3}>3</option><option value={4}>4</option>
+            </select>
+          </label>
+          <div className="flex gap-2">
+            <button onClick={save} disabled={patch.isPending}
+                    className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
+              Save
+            </button>
+            <button onClick={toggleDisabled}
+                    className="bg-slate-700 hover:bg-slate-600 rounded px-3 py-1.5">
+              {slot.status === 'disabled' ? 'Enable' : 'Disable'}
+            </button>
+            <button onClick={() => setConfirming(true)}
+                    className="bg-red-700 hover:bg-red-600 text-white rounded px-3 py-1.5 ml-auto">
+              Delete
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Attempts</h2>
+        <AttemptList attempts={slot.attempts} />
+      </section>
+
+      <ConfirmDialog
+        open={confirming}
+        title="Delete this wanted slot?"
+        body="This cannot be undone."
+        confirmLabel="Confirm"
+        onConfirm={confirmDelete}
+        onCancel={() => setConfirming(false)}
+      />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+```bash
+cd web && npm test -- src/pages/WantedDetailPage
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/pages/WantedDetailPage.*
+git commit -m "feat(web): WantedDetailPage with edit/disable/delete"
+```
+
+---
+
+## Task 15: App + Router + global Toaster, replace placeholder
+
+**Files:**
+- Create: `web/src/router.tsx`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Create `web/src/router.tsx`**
+
+```tsx
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+import { LoginPage } from './pages/LoginPage';
+import { WantedListPage } from './pages/WantedListPage';
+import { WantedNewPage } from './pages/WantedNewPage';
+import { WantedDetailPage } from './pages/WantedDetailPage';
+import { ProtectedRoute } from './auth/ProtectedRoute';
+
+const router = createBrowserRouter([
+  { path: '/login', element: <LoginPage /> },
+  {
+    element: <ProtectedRoute />,
+    children: [
+      { path: '/wanted', element: <WantedListPage /> },
+      { path: '/wanted/new', element: <WantedNewPage /> },
+      { path: '/wanted/:id', element: <WantedDetailPage /> },
+    ],
+  },
+  { path: '*', element: <Navigate to="/wanted" replace /> },
+]);
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}
+```
+
+- [ ] **Step 2: Replace `web/src/App.tsx`**
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'sonner';
+import { AuthProvider } from './auth/AuthProvider';
+import { AppRouter } from './router';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { refetchOnWindowFocus: true, retry: false },
+  },
+});
+
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <AppRouter />
+        <Toaster theme="dark" position="top-right" richColors />
+      </AuthProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+- [ ] **Step 3: Type-check and full test run**
+
+```bash
+cd web && npx tsc --noEmit && npm test
+```
+
+Expected: no type errors; all tests pass.
+
+- [ ] **Step 4: Build smoke test**
+
+```bash
+cd web && npm run build
+```
+
+Expected: `dist/index.html`, `dist/assets/*.js` produced.
+
+- [ ] **Step 5: Manual dev smoke test** (optional, requires running API on :8000)
+
+```bash
+cd web && npm run dev
+# Open http://localhost:5173 → /login should render.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/App.tsx web/src/router.tsx
+git commit -m "feat(web): wire App, router, Toaster"
+```
+
+---
+
+## Task 16: Dockerfile + nginx + runtime config
+
+**Files:**
+- Create: `web/Dockerfile`, `web/nginx.conf`, `web/entrypoint.sh`
+
+- [ ] **Step 1: Create `web/nginx.conf`**
+
+```nginx
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA fallback
+  location / {
+    try_files $uri /index.html;
+  }
+
+  # Long-cache hashed assets
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+
+  # config.js is rewritten at container start; never cache.
+  location = /config.js {
+    add_header Cache-Control "no-store";
+  }
+}
+```
+
+- [ ] **Step 2: Create `web/entrypoint.sh`**
+
+```sh
+#!/bin/sh
+set -e
+: "${API_BASE_URL:=}"
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__TSA_CONFIG__ = { apiBaseUrl: "${API_BASE_URL}" };
+EOF
+exec nginx -g 'daemon off;'
+```
+
+Make executable (the Dockerfile will also `chmod` it):
+
+```bash
+chmod +x web/entrypoint.sh
+```
+
+- [ ] **Step 3: Create `web/Dockerfile`**
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+- [ ] **Step 4: Local docker build smoke test**
+
+```bash
+cd web && docker build -t tee-sniper-web:dev .
+docker run --rm -p 8080:80 -e API_BASE_URL=http://host.docker.internal:8000 \
+           tee-sniper-web:dev &
+sleep 2
+curl -sI http://localhost:8080/ | head -1     # expect 200
+curl -s  http://localhost:8080/config.js      # expect window.__TSA_CONFIG__
+docker stop $(docker ps -q --filter ancestor=tee-sniper-web:dev)
+```
+
+Expected: index.html served, `/config.js` contains the env-injected base URL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/Dockerfile web/nginx.conf web/entrypoint.sh
+git commit -m "build(web): Dockerfile + nginx + runtime config.js"
+```
+
+---
+
+## Task 17: Helm chart `charts/tee-sniper-web`
+
+**Files:**
+- Create: `charts/tee-sniper-web/Chart.yaml`, `values.yaml`, `templates/_helpers.tpl`, `templates/deployment.yaml`, `templates/service.yaml`, `templates/ingress.yaml`, `templates/configmap.yaml`
+
+Mirror the structure of `charts/tee-sniper-api`. Inspect that chart first and reuse its naming conventions for `_helpers.tpl`.
+
+- [ ] **Step 1: Read the existing API chart for conventions**
+
+```bash
+ls charts/tee-sniper-api/templates/
+cat charts/tee-sniper-api/Chart.yaml
+cat charts/tee-sniper-api/values.yaml
+```
+
+Use the same labels, helpers, image-pull-secret patterns.
+
+- [ ] **Step 2: Create `charts/tee-sniper-web/Chart.yaml`**
+
+```yaml
+apiVersion: v2
+name: tee-sniper-web
+description: nginx-served React UI for tee-sniper wanted tee-times
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+```
+
+- [ ] **Step 3: Create `charts/tee-sniper-web/values.yaml`**
+
+```yaml
+image:
+  repository: ghcr.io/<owner>/tee-sniper-web
+  tag: ""              # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+# Empty string → browser uses relative /api/* (same-host ingress).
+apiBaseUrl: ""
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  host: tee-sniper.example.com
+  tls:
+    enabled: false
+    secretName: ""
+  # Path-based split: /api/* → API service, /* → this service.
+  apiServiceName: tee-sniper-api
+  apiServicePort: 80
+
+resources:
+  limits:   { cpu: 100m, memory: 64Mi }
+  requests: { cpu: 10m,  memory: 32Mi }
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+```
+
+Replace `<owner>` with the actual GHCR org (matching the API chart).
+
+- [ ] **Step 4: Create `charts/tee-sniper-web/templates/_helpers.tpl`**
+
+```yaml
+{{- define "tee-sniper-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tee-sniper-web.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "tee-sniper-web.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "tee-sniper-web.labels" -}}
+app.kubernetes.io/name: {{ include "tee-sniper-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "tee-sniper-web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tee-sniper-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+```
+
+- [ ] **Step 5: Create `templates/deployment.yaml`**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "tee-sniper-web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "tee-sniper-web.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          env:
+            - name: API_BASE_URL
+              value: {{ .Values.apiBaseUrl | quote }}
+          readinessProbe:
+            httpGet: { path: /, port: 80 }
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+```
+
+- [ ] **Step 6: Create `templates/service.yaml`**
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector: {{- include "tee-sniper-web.selectorLabels" . | nindent 4 }}
+```
+
+- [ ] **Step 7: Create `templates/ingress.yaml`**
+
+```yaml
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tee-sniper-web.fullname" . }}
+  labels: {{- include "tee-sniper-web.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts: [{{ .Values.ingress.host | quote }}]
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.apiServiceName }}
+                port: { number: {{ .Values.ingress.apiServicePort }} }
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tee-sniper-web.fullname" . }}
+                port: { number: {{ .Values.service.port }} }
+{{- end }}
+```
+
+- [ ] **Step 8: Lint and template-render**
+
+```bash
+helm lint charts/tee-sniper-web
+helm template charts/tee-sniper-web > /tmp/web-render.yaml
+head -40 /tmp/web-render.yaml
+```
+
+Expected: lint passes, render contains Deployment + Service + Ingress.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add charts/tee-sniper-web/
+git commit -m "build(charts): add tee-sniper-web Helm chart"
+```
+
+---
+
+## Task 18: CI workflow
+
+**Files:**
+- Create: `.github/workflows/web-build.yml`
+
+- [ ] **Step 1: Read the existing API workflow for parity**
+
+```bash
+cat .github/workflows/api-build.yml
+```
+
+Match its triggers, permissions, image-push strategy.
+
+- [ ] **Step 2: Create `.github/workflows/web-build.yml`**
+
+```yaml
+name: web build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-build.yml'
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-build.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: web } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test -- --reporter=default
+      - run: npm run build
+
+  image:
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: web
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}-web:latest
+            ghcr.io/${{ github.repository }}-web:${{ github.sha }}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/web-build.yml
+git commit -m "ci: add web-build workflow"
+```
+
+---
+
+## Task 19: Documentation — `web/README.md` and `CLAUDE.md`
+
+**Files:**
+- Create: `web/README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Create `web/README.md`**
+
+```markdown
+# tee-sniper-web
+
+React SPA for the wanted tee-times workflow. Calls the FastAPI backend at
+`/api/*` (configurable via `API_BASE_URL` at container start).
+
+## Stack
+
+Vite + React 18 + TypeScript + Tailwind + TanStack Query + React Router +
+Zod + react-hook-form + sonner. Tests use Vitest + React Testing Library +
+MSW.
+
+## Development
+
+```bash
+cd web
+npm install
+npm run dev          # serves on :5173, proxies /api → http://localhost:8000
+```
+
+Run the API alongside (see top-level CLAUDE.md). The login flow needs both.
+
+## Testing
+
+```bash
+npm test             # vitest run
+npm run test:watch
+npm run lint
+npm run build
+```
+
+## Configuration
+
+The browser reads its API base URL from `window.__TSA_CONFIG__.apiBaseUrl`,
+which is rewritten by `entrypoint.sh` from the `API_BASE_URL` env var at
+container start. Default `""` → relative `/api/*` requests (works when the
+ingress routes `/api/*` to the API service on the same host).
+
+## Deployment
+
+Built into a multi-stage Docker image (`web/Dockerfile`) and deployed by
+the Helm chart at `charts/tee-sniper-web`.
+```
+
+- [ ] **Step 2: Append a Web UI section to `CLAUDE.md`**
+
+Insert after the existing "MCP Plan History" section:
+
+```markdown
+## Web UI (`web/`)
+
+React SPA for the wanted tee-times workflow. Login + full CRUD over
+`/api/wanted`. Stack: Vite + React + TypeScript + Tailwind + TanStack
+Query + React Router + Zod + react-hook-form + Vitest + MSW. Deployed via
+`charts/tee-sniper-web` (nginx serving the `dist/` baked into the image).
+
+```bash
+cd web
+npm install
+npm run dev    # :5173, proxies /api to http://localhost:8000
+npm test
+npm run build
+```
+
+The browser never sees the AES shared secret. It calls
+`POST /api/encrypt-credentials` (added in this iteration) to get an
+encrypted blob used by `/api/login` and by wanted-slot create.
+
+- Spec: `docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md`
+- Plan: `docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md`
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/README.md CLAUDE.md
+git commit -m "docs: web/ README + CLAUDE.md web UI section"
+```
+
+---
+
+## Task 20: Final verification
+
+- [ ] **Step 1: Whole-repo regression — API tests**
+
+```bash
+cd api && .venv/bin/python -m pytest tests/ -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Whole-repo regression — Go tests**
+
+```bash
+cd /Users/stevebennett/Code/tee-sniper-web-ui
+go test ./...
+```
+
+Expected: all pass (Go side untouched, sanity check).
+
+- [ ] **Step 3: Whole-repo regression — web tests**
+
+```bash
+cd web && npm run lint && npm test && npm run build
+```
+
+Expected: lint clean, all tests pass, build succeeds.
+
+- [ ] **Step 4: Helm lint**
+
+```bash
+helm lint charts/tee-sniper-web charts/tee-sniper-api
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Verify branch state for PR**
+
+```bash
+git log --oneline origin/main..HEAD
+git status
+```
+
+Expected: ~20 atomic commits on `web/wanted-ui`, clean working tree.
+
+- [ ] **Step 6: Controller pushes branch and opens PR**
+
+The controller (not the implementer subagent) runs:
+
+```bash
+git push -u origin web/wanted-ui
+gh pr create --base main --head web/wanted-ui \
+  --title "Wanted tee-times web UI" \
+  --body "$(cat <<'EOF'
+Implements the React SPA for wanted tee-times per
+`docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md`.
+
+- New `web/` package (Vite + React + TS + Tailwind + TanStack Query)
+- New `POST /api/encrypt-credentials` endpoint
+- New `charts/tee-sniper-web` Helm chart (nginx ingress shares the host
+  with the API chart: `/api/*` → API, `/*` → web)
+- New `.github/workflows/web-build.yml` (test + build + GHCR image push)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: login + CRUD pages, encrypt endpoint, auth lifecycle, partner picker, attempt timeline, error handling, MSW tests, Dockerfile, Helm chart, CI, docs — each maps to a task.
+- Placeholders: none — every step has concrete code or commands.
+- Type consistency: `WantedResponse`, `CreateOneShotRequest`, `CreateRecurringRequest`, `PatchWantedRequest`, `Partner`, `Attempt`, `Notify` are defined once in `api/types.ts` and reused. `useAuth().login` signature matches `AuthProvider`'s exposed contract throughout.
+- One known nit deferred to implementation: `Task 14`'s detail-page form initialises with a `setState` during render guarded by `start_time === ''`. If React StrictMode causes the double-invoke to look weird in dev, swap to a `useEffect`. Functionally equivalent; left as-is for plan brevity.

--- a/docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md
+++ b/docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md
@@ -1,0 +1,289 @@
+# Wanted Tee-Times Web UI — Design
+
+**Status:** approved (brainstorming)
+**Scope:** React SPA covering login + full CRUD over wanted tee-time requests.
+Out of scope: live tee-time browse/book, partner management.
+
+## Goals
+
+A small single-page app that lets a logged-in user manage their persisted
+auto-booking requests (`/api/wanted`): list them at a glance, create one-shot
+or recurring slots, edit/disable/delete, and inspect attempt history.
+
+## Non-goals
+
+- Browsing or booking tee times directly.
+- Managing partners (read-only consumption of `/api/partners` for the picker).
+- Multi-user account features (this is a personal tool).
+- End-to-end browser tests in this iteration.
+
+## High-level architecture
+
+```
+                 ┌───────────────────────┐
+ Browser (SPA) ──┤ nginx (charts/web)    │── /api/* ──▶ FastAPI (charts/api)
+                 │ serves dist/ + /api ↗ │              ── Redis
+                 └───────────────────────┘
+```
+
+- New package at `web/` (sibling to `api/`, `mcp/`) built with Vite +
+  React + TypeScript + Tailwind + TanStack Query + React Router.
+- New nginx Helm release `charts/tee-sniper-web` deployed alongside the API.
+  Ingress routes `/api/*` to the API service and `/*` to the web service, so
+  the browser issues same-origin relative requests and CORS is unneeded.
+- One new backend endpoint (`POST /api/encrypt-credentials`) added to the
+  existing FastAPI app so the browser never holds the AES shared secret.
+
+## Repo layout
+
+```
+web/
+  package.json, vite.config.ts, tsconfig.json, tailwind.config.ts
+  src/
+    main.tsx, App.tsx, router.tsx
+    api/        # typed client + fetch wrapper + ApiError
+    auth/       # AuthProvider, useAuth, ProtectedRoute
+    crypto/     # thin wrapper around /api/encrypt-credentials
+    pages/      { LoginPage, WantedListPage, WantedDetailPage, WantedNewPage }
+    components/ { WantedCard, StatusPill, AttemptList,
+                  RecurringForm, OneShotForm, NotifyFields,
+                  PartnerPicker, ConfirmDialog }
+    hooks/      { useWantedList, useWanted, useCreateWanted,
+                  usePatchWanted, useDeleteWanted, useLogin, usePartners }
+  test/         # vitest setup, MSW handlers
+  Dockerfile    # multi-stage: node build → nginx:alpine serving dist/
+  nginx.conf    # SPA fallback (try_files), runtime /config.js endpoint
+  README.md
+
+charts/tee-sniper-web/
+  Chart.yaml, values.yaml
+  templates/{deployment,service,ingress,configmap}.yaml
+
+.github/workflows/web-build.yml   # lint + test + build + push GHCR image
+```
+
+## Backend change: `POST /api/encrypt-credentials`
+
+Added to `api/app/routers/booking.py`. Auth-free (login can't precede it).
+
+```python
+class EncryptRequest(BaseModel):
+    username: str
+    pin: str
+
+class EncryptResponse(BaseModel):
+    credentials: str  # base64 AES-256-GCM blob
+
+@router.post("/encrypt-credentials", response_model=EncryptResponse)
+async def encrypt_credentials(
+    body: EncryptRequest,
+    encryption: EncryptionService = Depends(get_encryption_service),
+) -> EncryptResponse:
+    return EncryptResponse(
+        credentials=encryption.encrypt_credentials(body.username, body.pin),
+    )
+```
+
+Rationale for auth-free: the booking site itself validates `username:pin` on
+the next `/api/login` call, so this endpoint is not a meaningful oracle — it
+just encrypts arbitrary bytes with a key the server already controls. Tested
+in `api/tests/test_booking_routes.py` with a roundtrip through
+`EncryptionService.decrypt_credentials`.
+
+## Auth & credential lifecycle (browser)
+
+A single `AuthProvider` (React context) owns:
+
+| State              | Persistence          | Notes                                      |
+|--------------------|----------------------|--------------------------------------------|
+| `token`            | sessionStorage       | Survives reload, dies with the tab.        |
+| `username`         | sessionStorage       | For display only ("Logged in as …").       |
+| `credentialsBlob`  | memory only          | Lost on reload; only needed for *create*.  |
+
+**Login flow:**
+
+1. User submits `{username, pin}` to `POST /api/encrypt-credentials`.
+2. POST `/api/login` with the returned blob → `{access_token, expires_at}`.
+3. Store token + username in state and sessionStorage, blob in memory only,
+   redirect to `/wanted`.
+
+**Authed fetch wrapper** attaches `Authorization: Bearer ${token}`. On any
+`401` it clears auth state and redirects to `/login` — no silent refresh.
+
+**Slot creation** attaches the in-memory blob to the POST body. If the blob
+is absent (post-reload), the create form shows an inline "Re-enter PIN to
+save" field that calls `/api/encrypt-credentials` again before submit.
+Viewing, editing, disabling, and deleting existing slots never need the blob
+(each slot already has its own stored credentials, and PATCH only sends the
+new blob if `credentials` is explicitly being changed).
+
+`ProtectedRoute` wraps `/wanted/*` and redirects to `/login` when there's no
+token.
+
+## Pages
+
+### `/login`
+
+Centered card: username, PIN, "Sign in". Errors surface inline:
+- `401` → "Invalid username or PIN."
+- `502` → "Booking site unreachable; try again shortly."
+- network/other → "Something went wrong: <detail>."
+
+### `/wanted` (list)
+
+Card grid (`grid-cols-1 md:grid-cols-2 lg:grid-cols-3`). Each `WantedCard`
+shows:
+
+- Title — for one-shot: formatted target_date (e.g. "Sat 24 May"); for
+  recurring: "Every \<Day\>".
+- Time window, `num_slots`, partner count.
+- `StatusPill` (pending / booked / expired / disabled).
+- Last attempt summary ("2h ago · no_slots", "booked 09:42", or "No attempts
+  yet").
+
+Header: app name, "+ New" button, "Logged in as <username> · Logout".
+Below the header, a chip row filters by status (All / Pending / Booked /
+Disabled / Expired). Filter is purely client-side over the cached list.
+
+`useWantedList` (`GET /api/wanted`):
+- `refetchInterval: 60_000`
+- `refetchOnWindowFocus: true`
+
+Clicking a card navigates to `/wanted/:id`.
+
+### `/wanted/new`
+
+Segmented toggle at top: **One-shot** ↔ **Recurring**.
+
+Common fields:
+- `start_time`, `end_time` — `<input type="time">`, Zod-validated
+  (`end_time > start_time`).
+- `num_slots` — 1–4 (segmented control).
+- Partners — `PartnerPicker` pulls from `GET /api/partners`, multi-select,
+  max 3.
+- Notify (optional) — `to` (E.164 input, validated), `from` (optional).
+
+One-shot extra:
+- `target_date` — date input, must satisfy `today ≤ d ≤ today + 7` (matches
+  the 8-day booking window the worker enforces via
+  `app/services/scheduling.py`). The client validates and the server is the
+  source of truth.
+
+Recurring extra:
+- `day_of_week` — Mon–Sun chip group, single-select (stored as 0=Monday per
+  the API).
+- `end_date` — optional date input.
+
+Submit → `POST /api/wanted?kind=one_shot|recurring` with the in-memory
+credentials blob. Success → toast + `navigate('/wanted')`.
+
+### `/wanted/:id`
+
+Two-column layout (stacks on mobile):
+
+**Left** — edit form pre-filled with the slot's current values. Only
+PATCH-able fields are editable (per `PatchWantedRequest`): `start_time`,
+`end_time`, `num_slots`, `partners`, `notify`. Buttons:
+- **Save** — `PATCH /api/wanted/:id`.
+- **Disable / Enable** — toggles via `{disabled: true|false}` in PATCH body.
+- **Delete** — opens `ConfirmDialog`, then `DELETE /api/wanted/:id` →
+  redirect to `/wanted`.
+
+**Right** — `AttemptList`: newest-first list of `attempts[]` entries. Each
+row shows timestamp, outcome pill, `booking_id` if booked, and `error` text
+when present. Empty state: "No attempts yet."
+
+## API client
+
+`src/api/client.ts` — small hand-rolled `fetch` wrapper (~80 lines):
+
+```ts
+class ApiError extends Error {
+  constructor(public status: number, public detail: string) { super(detail); }
+}
+
+async function request<T>(path: string, init?: RequestInit & { token?: string }): Promise<T>
+```
+
+Endpoint functions (typed): `login`, `encryptCredentials`, `listWanted`,
+`getWanted`, `createWanted`, `patchWanted`, `deleteWanted`, `listPartners`.
+Request/response types live in `src/api/types.ts` and are hand-mirrored from
+`api/app/models/{wanted,requests,responses}.py`. No codegen; the surface is
+small (~150 lines of types) and easy to keep in sync.
+
+React Query keys: `['wanted']`, `['wanted', id]`, `['partners']`. Mutations
+invalidate the relevant keys.
+
+## Error handling
+
+- Shared `<Toaster/>` (e.g. `sonner`) — one toast per `ApiError` from a
+  mutation or non-list query.
+- Form-level Zod errors render inline next to the field.
+- `401` from anywhere triggers `auth.logout()` (clears state + redirect).
+- `422` shows the FastAPI detail string inline above the form.
+
+## Testing
+
+- **Vitest + React Testing Library** for unit/component tests:
+  `AuthProvider` flow, `WantedCard` rendering by status, attempt timeline,
+  Zod form validation, partner picker constraints.
+- **MSW** for HTTP mocking. Handlers in `web/test/handlers.ts` cover happy
+  path + 401 + 422 + 502 for every endpoint.
+- No Playwright/E2E in this iteration.
+- CI: `web-build.yml` runs `npm ci && npm run lint && npm test &&
+  npm run build`, then builds + pushes the GHCR image on `main`.
+
+## Deployment
+
+`web/Dockerfile`:
+
+```Dockerfile
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build           # → /app/dist
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+`entrypoint.sh` writes `/usr/share/nginx/html/config.js` from the
+`API_BASE_URL` env var (defaults to `""` → relative `/api`), enabling
+per-environment configuration without rebuilding. `index.html` loads
+`/config.js` before the bundle and the API client reads
+`window.__TSA_CONFIG__.apiBaseUrl`.
+
+`nginx.conf`:
+- `try_files $uri /index.html;` for SPA routing.
+- No `/api` proxy in the container — handled at the ingress.
+
+`charts/tee-sniper-web/` mirrors `charts/tee-sniper-api`:
+- `Deployment` — image + `API_BASE_URL` env (default `""`).
+- `Service` — ClusterIP :80.
+- `Ingress` — host + path-based routing (`/api/*` → api service, `/*` → web
+  service).
+- `ConfigMap` — anything else worth templating.
+
+## Documentation
+
+- `web/README.md` — dev (`npm install`, `npm run dev` proxying to API on
+  `http://localhost:8000`), build, test, env vars, deployment notes.
+- `CLAUDE.md` gains a "Web UI" section pointing at `web/` and listing the
+  dev/test commands.
+
+## Workflow
+
+Per user preference for multi-phase plans: deliver as a **single PR** off a
+worktree from `main`, sequenced internally but landing together. Branch
+name: `web/wanted-ui`.
+
+## Open questions
+
+None at brainstorming time. Implementation-plan-level details (exact Zod
+schemas, Tailwind theme choices, ingress path conventions) deferred to the
+plan.

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+.git

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2022: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': 'warn',
+  },
+};

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -6,3 +6,5 @@ coverage
 vite.config.js
 vite.config.d.ts
 src/**/*.js
+test/**/*.js
+test/**/*.d.ts

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+coverage
+.env.local
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
+src/**/*.js

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]

--- a/web/MANUAL_TEST_PLAN.md
+++ b/web/MANUAL_TEST_PLAN.md
@@ -1,0 +1,117 @@
+# Manual Test Plan — Wanted Tee-Times Web UI
+
+## Preconditions / setup
+
+1. **Backend running** on `http://localhost:8000`:
+   - Redis reachable; `TSA_SHARED_SECRET` set; `TSA_PARTNERS_FILE` pointing at a
+     JSON `{id: name}` map (needed for the partner picker to be non-empty).
+   - Booking-site `base_url` configured.
+2. **Frontend**: `cd web && npm install && npm run dev` → open
+   `http://localhost:5173` (Vite proxies `/api` → `:8000`).
+3. Have **valid booking-site credentials** (member username + PIN) and at least
+   one **invalid** PIN for negative tests.
+
+---
+
+## A. Authentication
+
+| # | Steps | Expected |
+|---|-------|----------|
+| A1 | Visit `/wanted` (or any protected route) while logged out | Redirected to `/login` |
+| A2 | Submit empty username and/or PIN | Inline "Username required" / "PIN required"; no network call |
+| A3 | Log in with **valid** credentials | Lands on `/wanted`; header shows "Logged in as `<username>`" |
+| A4 | Log in with **invalid** PIN | Error "Invalid username or PIN." shown; stays on `/login` |
+| A5 | Stop the API, attempt login | Error "Booking site unreachable; try again shortly." (502) or a generic error if connection refused |
+| A6 | After A3, open DevTools → Application → Session Storage | `tsa.token`, `tsa.username`, `tsa.expiresAt` present; **no** `tsa.credentialsBlob` (blob is memory-only) |
+| A7 | After A3, reload the page | Still logged in (token persisted); list loads |
+| A8 | Click **Logout** | Returns to `/login`; sessionStorage `tsa.*` cleared |
+
+---
+
+## B. List page (`/wanted`)
+
+| # | Steps | Expected |
+|---|-------|----------|
+| B1 | Land on list with ≥1 slot | Card grid; each card shows title, time window, slots, partner count, status pill, last-attempt summary |
+| B2 | One-shot slot card | Title is the formatted date (e.g. "Sat 24 May") |
+| B3 | Recurring slot card | Title is "Every `<Day>`" |
+| B4 | Slot with no attempts | Shows "No attempts yet" |
+| B5 | Click filter chips (All / Pending / Booked / Disabled / Expired) | Grid filters client-side; only matching statuses show |
+| B6 | A `disabled` slot | Card appears dimmed (reduced opacity) |
+| B7 | Click a card | Navigates to `/wanted/:id` |
+| B8 | Leave the tab and return (window focus), or wait ~60s | List silently refetches (attempt history/status updates without manual reload) |
+| B9 | Empty/filtered-empty state | "No wanted slots match this filter." |
+
+---
+
+## C. Create — one-shot (`/wanted/new`)
+
+| # | Steps | Expected |
+|---|-------|----------|
+| C1 | Click "+ New" | Lands on `/wanted/new`, "One-shot" tab active |
+| C2 | Set end time ≤ start time, submit | Inline "End time must be after start time"; no submit |
+| C3 | Try a target date in the past or > 8 days out | Date input min=today, max=today+7 prevents/flags it |
+| C4 | Select 4th partner after 3 chosen | 4th checkbox disabled (cap of 3); already-checked boxes still uncheckable |
+| C5 | Enter a malformed notify "To" (not E.164) | Inline E.164 error; leaving notify blank is allowed (no error) |
+| C6 | Valid form → submit | Success toast "Wanted slot created"; navigates to `/wanted`; new card appears |
+| C7 | Inspect the create request (Network tab) | `POST /api/wanted?kind=one_shot`; body includes `credentials` (the blob), `target_date`, times, `num_slots`, `partners` |
+
+---
+
+## D. Create — recurring
+
+| # | Steps | Expected |
+|---|-------|----------|
+| D1 | Switch to "Recurring" tab | Day-of-week selector + optional end-date appear; target-date field gone |
+| D2 | Pick a day, valid window, submit | `POST /api/wanted?kind=recurring` with `day_of_week` (Mon=0…Sun=6); success toast + redirect |
+| D3 | Verify the day mapping | Selecting "Mon" sends `day_of_week: 0`; recurring card shows "Every Monday" |
+
+---
+
+## E. Credentials re-prompt (memory-only blob)
+
+| # | Steps | Expected |
+|---|-------|----------|
+| E1 | Log in, go to `/wanted/new` **without reloading** | No PIN prompt (in-memory blob reused); create works directly |
+| E2 | Reload the page, then go to `/wanted/new` | Amber "Re-enter your PIN to save credentials" prompt appears |
+| E3 | Submit with the PIN field filled | Re-encrypts via `/api/encrypt-credentials`, then creates the slot successfully |
+| E4 | Submit with PIN left blank (after reload) | Error toast "Re-enter PIN to save"; no slot created |
+
+---
+
+## F. Detail / edit (`/wanted/:id`)
+
+| # | Steps | Expected |
+|---|-------|----------|
+| F1 | Open a slot | Left: edit form pre-filled with current start/end/slots; right: attempt timeline; status pill shown |
+| F2 | Change times/slots → **Save** | `PATCH /api/wanted/:id`; "Saved" toast; values persist after reload |
+| F3 | Click **Disable** on a pending slot | Status → disabled (`{disabled:true}`); button now reads "Enable" |
+| F4 | Click **Enable** on a disabled slot | Status → pending |
+| F5 | Click **Delete** | ConfirmDialog "Delete this wanted slot?" appears |
+| F6 | Cancel the dialog | No deletion; stays on page |
+| F7 | Confirm deletion | `DELETE /api/wanted/:id`; "Deleted" toast; navigates to `/wanted`; card gone |
+| F8 | Slot with attempts | Timeline lists newest-first: timestamp, outcome, booking_id (if booked), error text (if failed) |
+| F9 | Save with an invalid window (end ≤ start) | Backend 422 surfaces as an error toast |
+
+---
+
+## G. Routing & errors
+
+| # | Steps | Expected |
+|---|-------|----------|
+| G1 | Visit an unknown path (e.g. `/foo`) | Redirects to `/wanted` (catch-all) |
+| G2 | Deep-link `/wanted/:id` while logged out | Redirected to `/login` |
+| G3 | Let the session expire / delete `tsa.token`, then trigger an API call | 401 → auth cleared → redirect to `/login` |
+| G4 | Network failure on the list | "Failed to load wanted slots." message |
+
+---
+
+## H. Deployment smoke (optional, needs Docker/k8s)
+
+| # | Steps | Expected |
+|---|-------|----------|
+| H1 | `docker build -t web web/` then run with `-e API_BASE_URL=https://host/api` | Container serves on :80 |
+| H2 | `GET /config.js` | Returns `window.__TSA_CONFIG__ = { apiBaseUrl: "https://host/api" };` |
+| H3 | Default (no `API_BASE_URL`) | `config.js` has `apiBaseUrl: ""` → app uses relative `/api/*` |
+| H4 | Refresh on a deep route (e.g. `/wanted/abc`) in the container | nginx `try_files` serves `index.html` (no 404) |
+| H5 | `helm template charts/tee-sniper-web` | Renders Deployment + Service + Ingress; ingress splits `/api` → API service, `/` → web |

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,41 @@
+# tee-sniper-web
+
+React SPA for the wanted tee-times workflow. Calls the FastAPI backend at
+`/api/*` (configurable via `API_BASE_URL` at container start).
+
+## Stack
+
+Vite + React 18 + TypeScript + Tailwind + TanStack Query + React Router +
+Zod + react-hook-form + sonner. Tests use Vitest + React Testing Library +
+MSW.
+
+## Development
+
+```bash
+cd web
+npm install
+npm run dev          # serves on :5173, proxies /api → http://localhost:8000
+```
+
+Run the API alongside (see top-level CLAUDE.md). The login flow needs both.
+
+## Testing
+
+```bash
+npm test             # vitest run
+npm run test:watch
+npm run lint
+npm run build
+```
+
+## Configuration
+
+The browser reads its API base URL from `window.__TSA_CONFIG__.apiBaseUrl`,
+which is rewritten by `entrypoint.sh` from the `API_BASE_URL` env var at
+container start. Default `""` → relative `/api/*` requests (works when the
+ingress routes `/api/*` to the API service on the same host).
+
+## Deployment
+
+Built into a multi-stage Docker image (`web/Dockerfile`) and deployed by
+the Helm chart at `charts/tee-sniper-web`.

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+: "${API_BASE_URL:=}"
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__TSA_CONFIG__ = { apiBaseUrl: "${API_BASE_URL}" };
+EOF
+exec nginx -g 'daemon off;'

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tee Sniper</title>
+    <script src="/config.js"></script>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,21 @@
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA fallback
+  location / {
+    try_files $uri /index.html;
+  }
+
+  # Long-cache hashed assets
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+
+  # config.js is rewritten at container start; never cache.
+  location = /config.js {
+    add_header Cache-Control "no-store";
+  }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,6251 @@
+{
+  "name": "tee-sniper-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tee-sniper-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hookform/resolvers": "^3.9.0",
+        "@tanstack/react-query": "^5.51.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.52.0",
+        "react-router-dom": "^6.26.0",
+        "sonner": "^1.5.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.6",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@typescript-eslint/eslint-plugin": "^7.16.0",
+        "@typescript-eslint/parser": "^7.16.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.19",
+        "eslint": "^8.57.0",
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-refresh": "^0.4.7",
+        "jsdom": "^24.1.0",
+        "msw": "^2.3.0",
+        "postcss": "^8.4.39",
+        "tailwindcss": "^3.4.6",
+        "typescript": "^5.5.0",
+        "vite": "^5.3.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.11.tgz",
+      "integrity": "sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.0.tgz",
+      "integrity": "sha512-eKtLGgFeSgkHqQD8J59AMZ9a4uD1D83iSIzt4YlTGD7liDen5rrjcUO1rVIGd9yC1gofryjtHbv+4ny4hkLWlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "tee-sniper-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.0",
+    "react-router-dom": "^6.26.0",
+    "sonner": "^1.5.0",
+    "zod": "^3.23.0",
+    "@hookform/resolvers": "^3.9.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/parser": "^7.16.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "jsdom": "^24.1.0",
+    "msw": "^2.3.0",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.6",
+    "typescript": "^5.5.0",
+    "vite": "^5.3.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: { tailwindcss: {}, autoprefixer: {} },
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,3 @@
+export function App() {
+  return <div className="p-8">Tee Sniper — bootstrapping…</div>;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'sonner';
+import { AuthProvider } from './auth/AuthProvider';
+import { AppRouter } from './router';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { refetchOnWindowFocus: true, retry: false },
+  },
+});
+
 export function App() {
-  return <div className="p-8">Tee Sniper — bootstrapping…</div>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <AppRouter />
+        <Toaster theme="dark" position="top-right" richColors />
+      </AuthProvider>
+    </QueryClientProvider>
+  );
 }

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,43 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server, baseUrl } from '../../test/handlers';
+import { ApiError, request } from './client';
+
+// Force apiBaseUrl() to return baseUrl during tests.
+beforeAll(() => {
+  window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl };
+});
+
+describe('request', () => {
+  it('returns parsed JSON on 2xx', async () => {
+    server.use(http.get(`${baseUrl}/ok`, () => HttpResponse.json({ hello: 'world' })));
+    await expect(request<{ hello: string }>('/ok')).resolves.toEqual({ hello: 'world' });
+  });
+
+  it('throws ApiError with detail on non-2xx', async () => {
+    server.use(
+      http.get(`${baseUrl}/bad`, () =>
+        HttpResponse.json({ detail: 'nope' }, { status: 422 }),
+      ),
+    );
+    await expect(request('/bad')).rejects.toBeInstanceOf(ApiError);
+    await expect(request('/bad')).rejects.toMatchObject({ status: 422, detail: 'nope' });
+  });
+
+  it('attaches Bearer token when provided', async () => {
+    let seenAuth: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/auth`, ({ request }) => {
+        seenAuth = request.headers.get('authorization');
+        return HttpResponse.json({});
+      }),
+    );
+    await request('/auth', { token: 'abc' });
+    expect(seenAuth).toBe('Bearer abc');
+  });
+
+  it('returns undefined for 204 No Content', async () => {
+    server.use(http.delete(`${baseUrl}/x`, () => new HttpResponse(null, { status: 204 })));
+    await expect(request('/x', { method: 'DELETE' })).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,46 @@
+import { apiBaseUrl } from '../config';
+
+export class ApiError extends Error {
+  constructor(public status: number, public detail: string) {
+    super(detail || `HTTP ${status}`);
+    this.name = 'ApiError';
+  }
+}
+
+export interface RequestOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+  token?: string | null;
+}
+
+export async function request<T = unknown>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const { token, body, headers, ...rest } = opts;
+  const init: RequestInit = {
+    ...rest,
+    headers: {
+      Accept: 'application/json',
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(headers as Record<string, string> | undefined),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  };
+
+  const resp = await fetch(`${apiBaseUrl()}${path}`, init);
+
+  if (resp.status === 204) return undefined as T;
+
+  const text = await resp.text();
+  const data = text ? safeParse(text) : null;
+
+  if (!resp.ok) {
+    const detail = typeof data === 'object' && data && 'detail' in data
+      ? String((data as { detail: unknown }).detail)
+      : text || resp.statusText;
+    throw new ApiError(resp.status, detail);
+  }
+  return data as T;
+}
+
+function safeParse(text: string): unknown {
+  try { return JSON.parse(text); } catch { return text; }
+}

--- a/web/src/api/endpoints.test.ts
+++ b/web/src/api/endpoints.test.ts
@@ -1,0 +1,45 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server, baseUrl } from '../../test/handlers';
+import * as api from './endpoints';
+
+beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+describe('endpoints', () => {
+  it('encryptCredentials posts plaintext', async () => {
+    const result = await api.encryptCredentials({ username: 'u', pin: 'p' });
+    expect(result.credentials).toBe('enc(u:p)');
+  });
+
+  it('login posts the blob', async () => {
+    const result = await api.login({ credentials: 'BLOB' });
+    expect(result.access_token).toBe('test-token');
+  });
+
+  it('listWanted sends the bearer token', async () => {
+    let auth: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/api/wanted`, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json([]);
+      }),
+    );
+    await api.listWanted('tok');
+    expect(auth).toBe('Bearer tok');
+  });
+
+  it('createWanted appends ?kind=', async () => {
+    let url: string | null = null;
+    server.use(
+      http.post(`${baseUrl}/api/wanted`, ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ id: 'x' }, { status: 201 });
+      }),
+    );
+    await api.createWanted('tok', 'one_shot', {
+      target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+      num_slots: 2, partners: [], credentials: 'BLOB',
+    });
+    expect(url).toContain('kind=one_shot');
+  });
+});

--- a/web/src/api/endpoints.ts
+++ b/web/src/api/endpoints.ts
@@ -1,0 +1,53 @@
+import { request } from './client';
+import type {
+  CreateOneShotRequest,
+  CreateRecurringRequest,
+  EncryptRequest,
+  EncryptResponse,
+  LoginRequest,
+  LoginResponse,
+  PartnerListResponse,
+  PatchWantedRequest,
+  WantedKind,
+  WantedResponse,
+} from './types';
+
+export function encryptCredentials(body: EncryptRequest): Promise<EncryptResponse> {
+  return request('/api/encrypt-credentials', { method: 'POST', body });
+}
+
+export function login(body: LoginRequest): Promise<LoginResponse> {
+  return request('/api/login', { method: 'POST', body });
+}
+
+export function listWanted(token: string): Promise<WantedResponse[]> {
+  return request('/api/wanted', { token });
+}
+
+export function getWanted(token: string, id: string): Promise<WantedResponse> {
+  return request(`/api/wanted/${id}`, { token });
+}
+
+export function createWanted(
+  token: string,
+  kind: WantedKind,
+  body: CreateOneShotRequest | CreateRecurringRequest,
+): Promise<WantedResponse> {
+  return request(`/api/wanted?kind=${kind}`, { method: 'POST', body, token });
+}
+
+export function patchWanted(
+  token: string,
+  id: string,
+  body: PatchWantedRequest,
+): Promise<WantedResponse> {
+  return request(`/api/wanted/${id}`, { method: 'PATCH', body, token });
+}
+
+export function deleteWanted(token: string, id: string): Promise<void> {
+  return request(`/api/wanted/${id}`, { method: 'DELETE', token });
+}
+
+export function listPartners(token: string): Promise<PartnerListResponse> {
+  return request('/api/partners', { token });
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,0 +1,72 @@
+export type WantedKind = 'one_shot' | 'recurring';
+export type WantedStatus = 'pending' | 'booked' | 'expired' | 'disabled';
+export type Outcome =
+  | 'booked' | 'no_slots' | 'auth_failed' | 'upstream_error' | 'booking_failed';
+
+export interface Notify { to: string; from?: string }
+
+export interface Attempt {
+  ts: string;
+  target_date: string;
+  outcome: Outcome;
+  booking_id?: string | null;
+  error?: string | null;
+}
+
+export interface WantedResponse {
+  id: string;
+  kind: WantedKind;
+  target_date: string | null;
+  day_of_week: number | null;
+  end_date: string | null;
+  start_time: string;
+  end_time: string;
+  num_slots: number;
+  partners: string[];
+  has_credentials: boolean;
+  notify: Notify | null;
+  status: WantedStatus;
+  attempts: Attempt[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LoginRequest { credentials: string }
+export interface LoginResponse { access_token: string; expires_at: string }
+
+export interface EncryptRequest { username: string; pin: string }
+export interface EncryptResponse { credentials: string }
+
+export interface CreateOneShotRequest {
+  target_date: string;          // YYYY-MM-DD
+  start_time: string;           // HH:MM
+  end_time: string;             // HH:MM
+  num_slots: number;
+  partners: string[];
+  credentials: string;
+  notify?: Notify | null;
+}
+
+export interface CreateRecurringRequest {
+  day_of_week: number;          // 0=Mon ... 6=Sun (matches Python weekday())
+  end_date?: string | null;
+  start_time: string;
+  end_time: string;
+  num_slots: number;
+  partners: string[];
+  credentials: string;
+  notify?: Notify | null;
+}
+
+export interface PatchWantedRequest {
+  start_time?: string;
+  end_time?: string;
+  num_slots?: number;
+  partners?: string[];
+  notify?: Notify | null;
+  disabled?: boolean;
+  credentials?: string;
+}
+
+export interface Partner { id: string; name: string }
+export interface PartnerListResponse { partners: Partner[] }

--- a/web/src/auth/AuthProvider.test.tsx
+++ b/web/src/auth/AuthProvider.test.tsx
@@ -1,0 +1,56 @@
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { AuthProvider } from './AuthProvider';
+import { useAuth } from './useAuth';
+
+function Probe() {
+  const a = useAuth();
+  return (
+    <div>
+      <span data-testid="token">{a.token ?? 'none'}</span>
+      <span data-testid="user">{a.username ?? 'none'}</span>
+      <button onClick={() => a.login('tok', 'alice', 'BLOB',
+                                     new Date('2099-01-01').toISOString())}>L</button>
+      <button onClick={() => a.logout()}>O</button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('starts logged out', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    expect(screen.getByTestId('token').textContent).toBe('none');
+  });
+
+  it('login() persists token + username to sessionStorage', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    expect(screen.getByTestId('token').textContent).toBe('tok');
+    expect(screen.getByTestId('user').textContent).toBe('alice');
+    expect(sessionStorage.getItem('tsa.token')).toBe('tok');
+    expect(sessionStorage.getItem('tsa.username')).toBe('alice');
+  });
+
+  it('logout() clears state and sessionStorage', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    act(() => { screen.getByText('O').click(); });
+    expect(screen.getByTestId('token').textContent).toBe('none');
+    expect(sessionStorage.getItem('tsa.token')).toBeNull();
+  });
+
+  it('rehydrates token from sessionStorage', () => {
+    sessionStorage.setItem('tsa.token', 'persisted');
+    sessionStorage.setItem('tsa.username', 'bob');
+    render(<AuthProvider><Probe /></AuthProvider>);
+    expect(screen.getByTestId('token').textContent).toBe('persisted');
+  });
+
+  it('does not persist credentialsBlob across reload', () => {
+    render(<AuthProvider><Probe /></AuthProvider>);
+    act(() => { screen.getByText('L').click(); });
+    expect(sessionStorage.getItem('tsa.credentialsBlob')).toBeNull();
+  });
+});

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -13,6 +13,7 @@ export interface AuthContextValue extends AuthState {
   setCredentialsBlob: (blob: string) => void;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
 const TOKEN_KEY = 'tsa.token';

--- a/web/src/auth/AuthProvider.tsx
+++ b/web/src/auth/AuthProvider.tsx
@@ -1,0 +1,70 @@
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+export interface AuthState {
+  token: string | null;
+  username: string | null;
+  credentialsBlob: string | null;
+  expiresAt: string | null;
+}
+
+export interface AuthContextValue extends AuthState {
+  login: (token: string, username: string, credentialsBlob: string, expiresAt: string) => void;
+  logout: () => void;
+  setCredentialsBlob: (blob: string) => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+const TOKEN_KEY = 'tsa.token';
+const USER_KEY = 'tsa.username';
+const EXP_KEY = 'tsa.expiresAt';
+
+function readInitial(): AuthState {
+  if (typeof window === 'undefined') {
+    return { token: null, username: null, credentialsBlob: null, expiresAt: null };
+  }
+  return {
+    token: sessionStorage.getItem(TOKEN_KEY),
+    username: sessionStorage.getItem(USER_KEY),
+    expiresAt: sessionStorage.getItem(EXP_KEY),
+    credentialsBlob: null,
+  };
+}
+
+export function AuthProvider({
+  children,
+  initial,
+}: {
+  children: ReactNode;
+  initial?: Partial<AuthState>;
+}) {
+  const [state, setState] = useState<AuthState>(() => ({ ...readInitial(), ...initial }));
+
+  const login = useCallback(
+    (token: string, username: string, credentialsBlob: string, expiresAt: string) => {
+      sessionStorage.setItem(TOKEN_KEY, token);
+      sessionStorage.setItem(USER_KEY, username);
+      sessionStorage.setItem(EXP_KEY, expiresAt);
+      setState({ token, username, credentialsBlob, expiresAt });
+    },
+    [],
+  );
+
+  const logout = useCallback(() => {
+    sessionStorage.removeItem(TOKEN_KEY);
+    sessionStorage.removeItem(USER_KEY);
+    sessionStorage.removeItem(EXP_KEY);
+    setState({ token: null, username: null, credentialsBlob: null, expiresAt: null });
+  }, []);
+
+  const setCredentialsBlob = useCallback((blob: string) => {
+    setState((s) => ({ ...s, credentialsBlob: blob }));
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ ...state, login, logout, setCredentialsBlob }),
+    [state, login, logout, setCredentialsBlob],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/web/src/auth/ProtectedRoute.test.tsx
+++ b/web/src/auth/ProtectedRoute.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from './AuthProvider';
+import { ProtectedRoute } from './ProtectedRoute';
+
+function setup(route: string, token: string | null) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthProvider initial={{ token }}>
+        <Routes>
+          <Route path="/login" element={<div>LOGIN</div>} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/secret" element={<div>SECRET</div>} />
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProtectedRoute', () => {
+  it('renders children when authed', () => {
+    setup('/secret', 'tok');
+    expect(screen.getByText('SECRET')).toBeInTheDocument();
+  });
+  it('redirects to /login when no token', () => {
+    setup('/secret', null);
+    expect(screen.getByText('LOGIN')).toBeInTheDocument();
+  });
+});

--- a/web/src/auth/ProtectedRoute.tsx
+++ b/web/src/auth/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+export function ProtectedRoute() {
+  const { token } = useAuth();
+  const location = useLocation();
+  if (!token) return <Navigate to="/login" replace state={{ from: location }} />;
+  return <Outlet />;
+}

--- a/web/src/auth/useAuth.ts
+++ b/web/src/auth/useAuth.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { AuthContext, type AuthContextValue } from './AuthProvider';
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/web/src/components/AttemptList.test.tsx
+++ b/web/src/components/AttemptList.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AttemptList } from './AttemptList';
+
+describe('AttemptList', () => {
+  it('shows empty state', () => {
+    render(<AttemptList attempts={[]} />);
+    expect(screen.getByText('No attempts yet.')).toBeInTheDocument();
+  });
+
+  it('renders newest first with outcome + error', () => {
+    render(<AttemptList attempts={[
+      { ts: '2026-05-19T10:00:00Z', target_date: '2026-05-20',
+        outcome: 'no_slots', booking_id: null, error: null },
+      { ts: '2026-05-19T12:00:00Z', target_date: '2026-05-20',
+        outcome: 'booking_failed', booking_id: null, error: 'partner unknown' },
+    ]} />);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[0]).toHaveTextContent('booking_failed');
+    expect(rows[0]).toHaveTextContent('partner unknown');
+  });
+});

--- a/web/src/components/AttemptList.tsx
+++ b/web/src/components/AttemptList.tsx
@@ -1,0 +1,26 @@
+import type { Attempt } from '../api/types';
+
+export function AttemptList({ attempts }: { attempts: Attempt[] }) {
+  if (attempts.length === 0) {
+    return <p className="text-slate-400">No attempts yet.</p>;
+  }
+  const sorted = [...attempts].sort((a, b) => (a.ts < b.ts ? 1 : -1));
+  return (
+    <ul className="space-y-2">
+      {sorted.map((a, i) => (
+        <li key={i} className="border border-slate-800 rounded p-3">
+          <div className="flex justify-between text-sm">
+            <span>{new Date(a.ts).toLocaleString()}</span>
+            <span className="font-mono">{a.outcome}</span>
+          </div>
+          {a.booking_id && (
+            <div className="text-xs text-slate-400">booking: {a.booking_id}</div>
+          )}
+          {a.error && (
+            <div className="text-xs text-red-400 mt-1">{a.error}</div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+export function ConfirmDialog({
+  open, title, body, confirmLabel = 'Confirm', onConfirm, onCancel,
+}: {
+  open: boolean;
+  title: string;
+  body?: ReactNode;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+         role="dialog" aria-modal="true">
+      <div className="bg-slate-900 border border-slate-700 rounded-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        {body && <div className="text-slate-300 mb-4">{body}</div>}
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded bg-slate-700">
+            Cancel
+          </button>
+          <button onClick={onConfirm} className="px-3 py-1.5 rounded bg-red-600 text-white">
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/NotifyFields.tsx
+++ b/web/src/components/NotifyFields.tsx
@@ -1,0 +1,32 @@
+import type { UseFormRegister, FieldErrors } from 'react-hook-form';
+
+export function NotifyFields({
+  register, errors,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: FieldErrors<any>;
+}) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm text-slate-300">Notify (optional)</legend>
+      <div>
+        <label className="text-xs text-slate-400" htmlFor="notify-to">To (E.164)</label>
+        <input id="notify-to" {...register('notify.to')}
+               placeholder="+14155551212"
+               className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+        {errors.notify && (errors.notify as any).to && (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          <p className="text-xs text-red-400">{(errors.notify as any).to.message}</p>
+        )}
+      </div>
+      <div>
+        <label className="text-xs text-slate-400" htmlFor="notify-from">From (optional)</label>
+        <input id="notify-from" {...register('notify.from')}
+               className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/components/OneShotForm.tsx
+++ b/web/src/components/OneShotForm.tsx
@@ -1,0 +1,35 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { SlotFormFields } from './SlotFormFields';
+import { oneShotSchema, type OneShotForm as OneShotValues } from '../lib/schemas';
+
+export interface OneShotSubmit extends OneShotValues {}
+
+const today = new Date().toISOString().slice(0, 10);
+const plus7 = new Date(Date.now() + 7 * 86400_000).toISOString().slice(0, 10);
+
+export function OneShotForm({ onSubmit, busy }: {
+  onSubmit: (v: OneShotSubmit) => void; busy: boolean;
+}) {
+  const { register, handleSubmit, control, formState: { errors } } = useForm<OneShotValues>({
+    resolver: zodResolver(oneShotSchema),
+    defaultValues: { num_slots: 1, partners: [] },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <label className="text-sm block">Target date
+        <input type="date" min={today} max={plus7}
+               {...register('target_date')}
+               className="block bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        {errors.target_date && (
+          <p className="text-xs text-red-400">{errors.target_date.message}</p>
+        )}
+      </label>
+      <SlotFormFields register={register} control={control} errors={errors} />
+      <button type="submit" disabled={busy}
+              className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-2 disabled:opacity-50">
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </form>
+  );
+}

--- a/web/src/components/PartnerPicker.test.tsx
+++ b/web/src/components/PartnerPicker.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { PartnerPicker } from './PartnerPicker';
+import { AuthProvider } from '../auth/AuthProvider';
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AuthProvider initial={{ token: 'tok' }}>{ui}</AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PartnerPicker', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('lists partners and toggles selection up to 3', async () => {
+    server.use(http.get(`${baseUrl}/api/partners`, () =>
+      HttpResponse.json({ partners: [
+        { id: 'a', name: 'Alice' },
+        { id: 'b', name: 'Bob' },
+        { id: 'c', name: 'Carol' },
+        { id: 'd', name: 'Dave' },
+      ]}),
+    ));
+    const onChange = vi.fn();
+    wrap(<PartnerPicker value={[]} onChange={onChange} />);
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Alice'));
+    expect(onChange).toHaveBeenLastCalledWith(['a']);
+  });
+
+  it('disables remaining checkboxes once 3 selected', async () => {
+    server.use(http.get(`${baseUrl}/api/partners`, () =>
+      HttpResponse.json({ partners: [
+        { id: 'a', name: 'A' }, { id: 'b', name: 'B' },
+        { id: 'c', name: 'C' }, { id: 'd', name: 'D' },
+      ]}),
+    ));
+    wrap(<PartnerPicker value={['a','b','c']} onChange={() => {}} />);
+    expect((await screen.findByLabelText('D'))).toBeDisabled();
+    expect(screen.getByLabelText('A')).not.toBeDisabled();
+  });
+});

--- a/web/src/components/PartnerPicker.tsx
+++ b/web/src/components/PartnerPicker.tsx
@@ -1,0 +1,38 @@
+import { usePartners } from '../hooks/usePartners';
+
+export function PartnerPicker({
+  value, onChange,
+}: { value: string[]; onChange: (next: string[]) => void }) {
+  const { data: partners = [], isLoading } = usePartners();
+  const atCap = value.length >= 3;
+
+  function toggle(id: string) {
+    if (value.includes(id)) onChange(value.filter((x) => x !== id));
+    else if (!atCap) onChange([...value, id]);
+  }
+
+  if (isLoading) return <p className="text-slate-400">Loading partners…</p>;
+  if (partners.length === 0) {
+    return <p className="text-slate-400 text-sm">No partners configured.</p>;
+  }
+  return (
+    <fieldset className="grid grid-cols-2 gap-2">
+      <legend className="text-sm text-slate-300 mb-1">Partners (max 3)</legend>
+      {partners.map((p) => {
+        const checked = value.includes(p.id);
+        return (
+          <label key={p.id} className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              aria-label={p.name}
+              checked={checked}
+              disabled={!checked && atCap}
+              onChange={() => toggle(p.id)}
+            />
+            {p.name}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/web/src/components/RecurringForm.tsx
+++ b/web/src/components/RecurringForm.tsx
@@ -1,0 +1,34 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { SlotFormFields } from './SlotFormFields';
+import { recurringSchema, type RecurringForm as RecurringValues } from '../lib/schemas';
+
+const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+
+export function RecurringForm({ onSubmit, busy }: {
+  onSubmit: (v: RecurringValues) => void; busy: boolean;
+}) {
+  const { register, handleSubmit, control, formState: { errors } } = useForm<RecurringValues>({
+    resolver: zodResolver(recurringSchema),
+    defaultValues: { num_slots: 1, partners: [], day_of_week: 0 },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <label className="text-sm block">Day of week
+        <select {...register('day_of_week', { valueAsNumber: true })}
+                className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+          {DAYS.map((d, i) => <option key={i} value={i}>{d}</option>)}
+        </select>
+      </label>
+      <label className="text-sm block">End date (optional)
+        <input type="date" {...register('end_date')}
+               className="block bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+      </label>
+      <SlotFormFields register={register} control={control} errors={errors} />
+      <button type="submit" disabled={busy}
+              className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-2 disabled:opacity-50">
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </form>
+  );
+}

--- a/web/src/components/SlotFormFields.tsx
+++ b/web/src/components/SlotFormFields.tsx
@@ -1,0 +1,50 @@
+import { Controller, type Control, type UseFormRegister, type FieldErrors } from 'react-hook-form';
+import { PartnerPicker } from './PartnerPicker';
+import { NotifyFields } from './NotifyFields';
+
+export function SlotFormFields({
+  register, control, errors,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: FieldErrors<any>;
+}) {
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="text-sm">Start
+          <input type="time" step={60} {...register('start_time')}
+                 className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+        </label>
+        <label className="text-sm">End
+          <input type="time" step={60} {...register('end_time')}
+                 className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+          {errors.end_time && (
+            <p className="text-xs text-red-400">{String(errors.end_time.message)}</p>
+          )}
+        </label>
+      </div>
+
+      <label className="text-sm block">Slots
+        <select {...register('num_slots', { valueAsNumber: true })}
+                className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+          <option value={1}>1</option><option value={2}>2</option>
+          <option value={3}>3</option><option value={4}>4</option>
+        </select>
+      </label>
+
+      <Controller
+        control={control}
+        name="partners"
+        render={({ field }) => (
+          <PartnerPicker value={field.value ?? []} onChange={field.onChange} />
+        )}
+      />
+
+      <NotifyFields register={register} errors={errors} />
+    </>
+  );
+}

--- a/web/src/components/SlotFormFields.tsx
+++ b/web/src/components/SlotFormFields.tsx
@@ -1,14 +1,13 @@
-import { Controller, type Control, type UseFormRegister, type FieldErrors } from 'react-hook-form';
+import { Controller, type Control, type FieldValues, type UseFormRegister, type FieldErrors } from 'react-hook-form';
 import { PartnerPicker } from './PartnerPicker';
 import { NotifyFields } from './NotifyFields';
 
-export function SlotFormFields({
+export function SlotFormFields<T extends FieldValues>({
   register, control, errors,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   register: UseFormRegister<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control: Control<any>;
+  control: Control<T>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   errors: FieldErrors<any>;
 }) {
@@ -37,7 +36,7 @@ export function SlotFormFields({
       </label>
 
       <Controller
-        control={control}
+        control={control as Control<FieldValues>}
         name="partners"
         render={({ field }) => (
           <PartnerPicker value={field.value ?? []} onChange={field.onChange} />

--- a/web/src/components/StatusPill.test.tsx
+++ b/web/src/components/StatusPill.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatusPill } from './StatusPill';
+
+describe('StatusPill', () => {
+  it.each(['pending','booked','expired','disabled'] as const)('renders %s', (s) => {
+    render(<StatusPill status={s} />);
+    expect(screen.getByText(s.toUpperCase())).toBeInTheDocument();
+  });
+});

--- a/web/src/components/StatusPill.tsx
+++ b/web/src/components/StatusPill.tsx
@@ -1,0 +1,16 @@
+import type { WantedStatus } from '../api/types';
+
+const COLORS: Record<WantedStatus, string> = {
+  pending:  'bg-blue-600 text-white',
+  booked:   'bg-green-600 text-white',
+  expired:  'bg-amber-600 text-white',
+  disabled: 'bg-slate-600 text-slate-200',
+};
+
+export function StatusPill({ status }: { status: WantedStatus }) {
+  return (
+    <span className={`text-[11px] px-2 py-0.5 rounded-full ${COLORS[status]}`}>
+      {status.toUpperCase()}
+    </span>
+  );
+}

--- a/web/src/components/WantedCard.test.tsx
+++ b/web/src/components/WantedCard.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { WantedCard } from './WantedCard';
+import type { WantedResponse } from '../api/types';
+
+const base: WantedResponse = {
+  id: 'abc', kind: 'one_shot',
+  target_date: '2026-05-23', day_of_week: null, end_date: null,
+  start_time: '14:00', end_time: '16:30',
+  num_slots: 4, partners: ['p1','p2'],
+  has_credentials: true, notify: null,
+  status: 'pending', attempts: [],
+  created_at: '2026-05-19T00:00:00Z', updated_at: '2026-05-19T00:00:00Z',
+};
+
+describe('WantedCard', () => {
+  it('renders one_shot title from target_date', () => {
+    render(<MemoryRouter><WantedCard slot={base} /></MemoryRouter>);
+    expect(screen.getByText(/Sat\b.+May/)).toBeInTheDocument();
+    expect(screen.getByText('14:00–16:30 · 4 slots · 2 partners')).toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+    expect(screen.getByText('No attempts yet')).toBeInTheDocument();
+  });
+
+  it('renders recurring title from day_of_week', () => {
+    render(<MemoryRouter><WantedCard slot={{
+      ...base, kind: 'recurring', target_date: null, day_of_week: 6,
+    }} /></MemoryRouter>);
+    expect(screen.getByText('Every Sunday')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/WantedCard.tsx
+++ b/web/src/components/WantedCard.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import type { WantedResponse } from '../api/types';
+import { StatusPill } from './StatusPill';
+import { formatDayOfWeek, formatLastAttempt, formatTargetDate } from '../lib/format';
+
+export function WantedCard({ slot }: { slot: WantedResponse }) {
+  const title =
+    slot.kind === 'one_shot' && slot.target_date
+      ? formatTargetDate(slot.target_date)
+      : slot.day_of_week != null
+        ? formatDayOfWeek(slot.day_of_week)
+        : '—';
+
+  return (
+    <Link to={`/wanted/${slot.id}`}
+          className={`block border border-slate-700 rounded-lg p-3 hover:border-slate-500
+                      ${slot.status === 'disabled' ? 'opacity-60' : ''}`}>
+      <div className="flex justify-between items-start">
+        <strong>{title}</strong>
+        <StatusPill status={slot.status} />
+      </div>
+      <div className="text-sm text-slate-300 mt-1">
+        {slot.start_time}–{slot.end_time} · {slot.num_slots} slots
+        {slot.partners.length > 0 && ` · ${slot.partners.length} partners`}
+      </div>
+      <div className="text-xs text-slate-400 mt-1">{formatLastAttempt(slot.attempts)}</div>
+    </Link>
+  );
+}

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,0 +1,8 @@
+export function apiBaseUrl(): string {
+  // Runtime override via /config.js → window.__TSA_CONFIG__.
+  // Tests inject http://api.test via vitest globals.
+  if (typeof window !== 'undefined' && window.__TSA_CONFIG__?.apiBaseUrl !== undefined) {
+    return window.__TSA_CONFIG__.apiBaseUrl;
+  }
+  return '';
+}

--- a/web/src/hooks/useLogin.ts
+++ b/web/src/hooks/useLogin.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { encryptCredentials, login } from '../api/endpoints';
+import { useAuth } from '../auth/useAuth';
+
+export function useLogin() {
+  const auth = useAuth();
+  return useMutation({
+    mutationFn: async (vars: { username: string; pin: string }) => {
+      const { credentials } = await encryptCredentials(vars);
+      const { access_token, expires_at } = await login({ credentials });
+      auth.login(access_token, vars.username, credentials, expires_at);
+      return { access_token };
+    },
+  });
+}

--- a/web/src/hooks/usePartners.ts
+++ b/web/src/hooks/usePartners.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { listPartners } from '../api/endpoints';
+import { useAuth } from '../auth/useAuth';
+
+export function usePartners() {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['partners'],
+    queryFn: () => listPartners(token!).then((r) => r.partners),
+    enabled: !!token,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/hooks/useWanted.ts
+++ b/web/src/hooks/useWanted.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createWanted, deleteWanted, getWanted, listWanted, patchWanted,
+} from '../api/endpoints';
+import type {
+  CreateOneShotRequest, CreateRecurringRequest, PatchWantedRequest, WantedKind,
+} from '../api/types';
+import { useAuth } from '../auth/useAuth';
+
+export function useWantedList() {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['wanted'],
+    queryFn: () => listWanted(token!),
+    enabled: !!token,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useWanted(id: string) {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ['wanted', id],
+    queryFn: () => getWanted(token!, id),
+    enabled: !!token,
+  });
+}
+
+export function useCreateWanted() {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: {
+      kind: WantedKind;
+      body: CreateOneShotRequest | CreateRecurringRequest;
+    }) => createWanted(token!, vars.kind, vars.body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['wanted'] }),
+  });
+}
+
+export function usePatchWanted(id: string) {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PatchWantedRequest) => patchWanted(token!, id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['wanted'] });
+      qc.invalidateQueries({ queryKey: ['wanted', id] });
+    },
+  });
+}
+
+export function useDeleteWanted() {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteWanted(token!, id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['wanted'] }),
+  });
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatTargetDate, formatDayOfWeek, formatLastAttempt } from './format';
+
+describe('format helpers', () => {
+  it('formats a target date as "Sat 24 May"', () => {
+    expect(formatTargetDate('2026-05-23')).toMatch(/^Sat\b.+May$/);
+  });
+
+  it('formats day_of_week with Monday=0', () => {
+    expect(formatDayOfWeek(0)).toBe('Every Monday');
+    expect(formatDayOfWeek(6)).toBe('Every Sunday');
+  });
+
+  it('returns "No attempts yet" for empty array', () => {
+    expect(formatLastAttempt([])).toBe('No attempts yet');
+  });
+
+  it('summarises the most recent attempt', () => {
+    const a = [
+      { ts: '2026-05-19T10:00:00Z', target_date: '2026-05-20',
+        outcome: 'no_slots' as const, booking_id: null, error: null },
+      { ts: '2026-05-19T12:00:00Z', target_date: '2026-05-20',
+        outcome: 'booked' as const, booking_id: 'B1', error: null },
+    ];
+    expect(formatLastAttempt(a)).toMatch(/booked/);
+  });
+});

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,35 @@
+import type { Attempt } from '../api/types';
+
+const DAYS = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+const SHORT_DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+export function formatTargetDate(iso: string): string {
+  // Treat as a local calendar date (no TZ shifting).
+  const [y, m, d] = iso.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  // JS getDay(): 0=Sun..6=Sat. Map to our Mon=0 ordering for short day lookup.
+  const jsDow = date.getDay();
+  const shortIdx = jsDow === 0 ? 6 : jsDow - 1;
+  return `${SHORT_DAYS[shortIdx]} ${d} ${MONTHS[m - 1]}`;
+}
+
+export function formatDayOfWeek(dow: number): string {
+  return `Every ${DAYS[dow] ?? '?'}`;
+}
+
+export function formatLastAttempt(attempts: Attempt[]): string {
+  if (attempts.length === 0) return 'No attempts yet';
+  const last = [...attempts].sort((a, b) => (a.ts < b.ts ? 1 : -1))[0];
+  return `${relTime(last.ts)} · ${last.outcome}`;
+}
+
+function relTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}

--- a/web/src/lib/schemas.test.ts
+++ b/web/src/lib/schemas.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { oneShotSchema, recurringSchema, loginSchema } from './schemas';
+
+describe('schemas', () => {
+  it('login requires non-empty username + pin', () => {
+    expect(loginSchema.safeParse({ username: '', pin: 'x' }).success).toBe(false);
+    expect(loginSchema.safeParse({ username: 'u', pin: 'p' }).success).toBe(true);
+  });
+
+  it('one-shot rejects end_time <= start_time', () => {
+    const base = { target_date: '2026-05-25', start_time: '14:00', end_time: '14:00',
+                   num_slots: 1, partners: [] };
+    expect(oneShotSchema.safeParse(base).success).toBe(false);
+  });
+
+  it('one-shot accepts a valid window', () => {
+    expect(oneShotSchema.safeParse({
+      target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+      num_slots: 1, partners: [],
+    }).success).toBe(true);
+  });
+
+  it('partners max length 3', () => {
+    const base = { target_date: '2026-05-25', start_time: '14:00', end_time: '16:00',
+                   num_slots: 1, partners: ['a','b','c','d'] };
+    expect(oneShotSchema.safeParse(base).success).toBe(false);
+  });
+
+  it('recurring requires day_of_week 0..6', () => {
+    const ok = { day_of_week: 0, start_time: '09:00', end_time: '11:00',
+                 num_slots: 2, partners: [] };
+    expect(recurringSchema.safeParse(ok).success).toBe(true);
+    expect(recurringSchema.safeParse({ ...ok, day_of_week: 7 }).success).toBe(false);
+  });
+});

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -46,14 +46,6 @@ export const recurringSchema = refineWindow(
   }),
 );
 
-export const patchSchema = z.object({
-  start_time: z.string().regex(HHMM).optional(),
-  end_time:   z.string().regex(HHMM).optional(),
-  num_slots:  z.number().int().min(1).max(4).optional(),
-  partners:   z.array(z.string()).max(3).optional(),
-  notify:     notifySchema,
-});
-
 export type LoginForm     = z.infer<typeof loginSchema>;
 export type OneShotForm   = z.infer<typeof oneShotSchema>;
 export type RecurringForm = z.infer<typeof recurringSchema>;

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -9,10 +9,16 @@ export const loginSchema = z.object({
   pin:      z.string().min(1, 'PIN required'),
 });
 
-const notifySchema = z.object({
-  to:   z.string().regex(E164, 'Must be E.164, e.g. +14155551212'),
-  from: z.string().regex(E164).optional().or(z.literal('').transform(() => undefined)),
-}).optional();
+const notifySchema = z.preprocess(
+  (v) => {
+    if (v && typeof v === 'object' && (v as Record<string, unknown>).to === '') return undefined;
+    return v;
+  },
+  z.object({
+    to:   z.string().regex(E164, 'Must be E.164, e.g. +14155551212'),
+    from: z.string().regex(E164).optional().or(z.literal('').transform(() => undefined)),
+  }).optional(),
+);
 
 const commonShape = {
   start_time: z.string().regex(HHMM),

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const HHMM = /^\d{2}:\d{2}$/;
+const YMD  = /^\d{4}-\d{2}-\d{2}$/;
+const E164 = /^\+[1-9]\d{1,14}$/;
+
+export const loginSchema = z.object({
+  username: z.string().min(1, 'Username required'),
+  pin:      z.string().min(1, 'PIN required'),
+});
+
+const notifySchema = z.object({
+  to:   z.string().regex(E164, 'Must be E.164, e.g. +14155551212'),
+  from: z.string().regex(E164).optional().or(z.literal('').transform(() => undefined)),
+}).optional();
+
+const commonShape = {
+  start_time: z.string().regex(HHMM),
+  end_time:   z.string().regex(HHMM),
+  num_slots:  z.number().int().min(1).max(4),
+  partners:   z.array(z.string()).max(3),
+  notify:     notifySchema,
+};
+
+function refineWindow<T extends { start_time: string; end_time: string }>(s: z.ZodType<T>) {
+  return s.refine((v) => v.end_time > v.start_time, {
+    message: 'End time must be after start time', path: ['end_time'],
+  });
+}
+
+export const oneShotSchema = refineWindow(
+  z.object({ target_date: z.string().regex(YMD), ...commonShape }),
+);
+
+export const recurringSchema = refineWindow(
+  z.object({
+    day_of_week: z.number().int().min(0).max(6),
+    end_date: z.string().regex(YMD).optional().or(z.literal('').transform(() => undefined)),
+    ...commonShape,
+  }),
+);
+
+export const patchSchema = z.object({
+  start_time: z.string().regex(HHMM).optional(),
+  end_time:   z.string().regex(HHMM).optional(),
+  num_slots:  z.number().int().min(1).max(4).optional(),
+  partners:   z.array(z.string()).max(3).optional(),
+  notify:     notifySchema,
+});
+
+export type LoginForm     = z.infer<typeof loginSchema>;
+export type OneShotForm   = z.infer<typeof oneShotSchema>;
+export type RecurringForm = z.infer<typeof recurringSchema>;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -1,0 +1,38 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { LoginPage } from './LoginPage';
+import { Route, Routes } from 'react-router-dom';
+
+describe('LoginPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('logs in and navigates to /wanted', async () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/login' },
+    );
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice');
+    await userEvent.type(screen.getByLabelText(/pin/i), '1234');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+    expect(sessionStorage.getItem('tsa.token')).toBe('test-token');
+  });
+
+  it('shows "Invalid username or PIN" on 401', async () => {
+    server.use(http.post(`${baseUrl}/api/login`, () =>
+      HttpResponse.json({ detail: 'bad creds' }, { status: 401 }),
+    ));
+    renderWithProviders(<LoginPage />, { route: '/login' });
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice');
+    await userEvent.type(screen.getByLabelText(/pin/i), 'x');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(await screen.findByText(/Invalid username or PIN/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -13,8 +13,13 @@ export function LoginPage() {
   });
 
   const onSubmit = handleSubmit(async (values) => {
-    await m.mutateAsync(values);
-    navigate('/wanted');
+    try {
+      await m.mutateAsync(values);
+      navigate('/wanted');
+    } catch {
+      // Error is surfaced via m.error; swallow the rejection so it
+      // doesn't escape as an unhandled promise rejection.
+    }
   });
 
   const errorMsg =

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,51 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { ApiError } from '../api/client';
+import { useLogin } from '../hooks/useLogin';
+import { loginSchema, type LoginForm } from '../lib/schemas';
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const m = useLogin();
+  const { register, handleSubmit, formState: { errors } } = useForm<LoginForm>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await m.mutateAsync(values);
+    navigate('/wanted');
+  });
+
+  const errorMsg =
+    m.error instanceof ApiError
+      ? m.error.status === 401 ? 'Invalid username or PIN.'
+      : m.error.status === 502 ? 'Booking site unreachable; try again shortly.'
+      : `Login failed: ${m.error.detail}`
+      : null;
+
+  return (
+    <main className="min-h-screen grid place-items-center">
+      <form onSubmit={onSubmit}
+            className="w-full max-w-sm bg-slate-900 p-6 rounded-lg border border-slate-700 space-y-3">
+        <h1 className="text-xl font-semibold">Sign in</h1>
+        <label className="block text-sm">Username
+          <input {...register('username')} autoComplete="username"
+                 className="block w-full bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+          {errors.username && <p className="text-xs text-red-400">{errors.username.message}</p>}
+        </label>
+        <label className="block text-sm">PIN
+          <input type="password" {...register('pin')} autoComplete="current-password"
+                 className="block w-full bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+          {errors.pin && <p className="text-xs text-red-400">{errors.pin.message}</p>}
+        </label>
+        {errorMsg && <p className="text-sm text-red-400">{errorMsg}</p>}
+        <button type="submit" disabled={m.isPending}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-50
+                           text-white rounded px-3 py-2">
+          {m.isPending ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/web/src/pages/WantedDetailPage.test.tsx
+++ b/web/src/pages/WantedDetailPage.test.tsx
@@ -1,0 +1,43 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedDetailPage } from './WantedDetailPage';
+import { Route, Routes } from 'react-router-dom';
+import type { WantedResponse } from '../api/types';
+
+const slot: WantedResponse = {
+  id: 'abc', kind: 'one_shot', target_date: '2026-05-23',
+  day_of_week: null, end_date: null,
+  start_time: '14:00', end_time: '16:30', num_slots: 4, partners: [],
+  has_credentials: true, notify: null, status: 'pending',
+  attempts: [{ ts: '2026-05-19T10:00:00Z', target_date: '2026-05-23',
+               outcome: 'no_slots', booking_id: null, error: null }],
+  created_at: '', updated_at: '',
+};
+
+describe('WantedDetailPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('shows attempts and supports delete', async () => {
+    server.use(
+      http.get(`${baseUrl}/api/wanted/abc`, () => HttpResponse.json(slot)),
+      http.delete(`${baseUrl}/api/wanted/abc`, () =>
+        new HttpResponse(null, { status: 204 }),
+      ),
+    );
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/:id" element={<WantedDetailPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/wanted/abc', initialAuth: { token: 'tok' } },
+    );
+    expect(await screen.findByText('no_slots')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+  });
+});

--- a/web/src/pages/WantedDetailPage.test.tsx
+++ b/web/src/pages/WantedDetailPage.test.tsx
@@ -40,4 +40,45 @@ describe('WantedDetailPage', () => {
     await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
     await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
   });
+
+  it('has a back link to the list', async () => {
+    server.use(http.get(`${baseUrl}/api/wanted/abc`, () => HttpResponse.json(slot)));
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/:id" element={<WantedDetailPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/wanted/abc', initialAuth: { token: 'tok' } },
+    );
+    await userEvent.click(await screen.findByRole('link', { name: /back to wanted/i }));
+    expect(screen.getByText('LIST')).toBeInTheDocument();
+  });
+
+  it('edits partners and includes them in the save patch', async () => {
+    let patchBody: { partners?: string[] } | null = null;
+    server.use(
+      http.get(`${baseUrl}/api/wanted/abc`, () => HttpResponse.json(slot)),
+      http.get(`${baseUrl}/api/partners`, () =>
+        HttpResponse.json({ partners: [
+          { id: 'p1', name: 'Alice' },
+          { id: 'p2', name: 'Bob' },
+        ]}),
+      ),
+      http.patch(`${baseUrl}/api/wanted/abc`, async ({ request }) => {
+        patchBody = (await request.json()) as { partners?: string[] };
+        return HttpResponse.json({ ...slot, partners: patchBody.partners ?? [] });
+      }),
+    );
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/:id" element={<WantedDetailPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      { route: '/wanted/abc', initialAuth: { token: 'tok' } },
+    );
+    await userEvent.click(await screen.findByLabelText('Alice'));
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(patchBody).not.toBeNull());
+    expect(patchBody!.partners).toEqual(['p1']);
+  });
 });

--- a/web/src/pages/WantedDetailPage.tsx
+++ b/web/src/pages/WantedDetailPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ApiError } from '../api/client';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { AttemptList } from '../components/AttemptList';
+import { StatusPill } from '../components/StatusPill';
+import { useDeleteWanted, usePatchWanted, useWanted } from '../hooks/useWanted';
+
+export function WantedDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const { data: slot, isLoading } = useWanted(id);
+  const patch = usePatchWanted(id);
+  const del = useDeleteWanted();
+  const [confirming, setConfirming] = useState(false);
+  const [form, setForm] = useState({ start_time: '', end_time: '', num_slots: 1 });
+
+  useEffect(() => {
+    if (slot) {
+      setForm({ start_time: slot.start_time, end_time: slot.end_time, num_slots: slot.num_slots });
+    }
+  }, [slot]);
+
+  if (isLoading || !slot) return <main className="p-6 text-slate-400">Loading…</main>;
+
+  async function save() {
+    try { await patch.mutateAsync(form); toast.success('Saved'); }
+    catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  async function toggleDisabled() {
+    try {
+      await patch.mutateAsync({ disabled: slot!.status !== 'disabled' });
+    } catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  async function confirmDelete() {
+    try {
+      await del.mutateAsync(slot!.id);
+      toast.success('Deleted');
+      navigate('/wanted');
+    } catch (e) { toast.error(e instanceof ApiError ? e.detail : String(e)); }
+  }
+
+  return (
+    <main className="max-w-5xl mx-auto p-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h1 className="text-xl font-semibold">Edit</h1>
+          <StatusPill status={slot.status} />
+        </div>
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm">Start
+              <input type="time" value={form.start_time}
+                     onChange={(e) => setForm({ ...form, start_time: e.target.value })}
+                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+            </label>
+            <label className="text-sm">End
+              <input type="time" value={form.end_time}
+                     onChange={(e) => setForm({ ...form, end_time: e.target.value })}
+                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+            </label>
+          </div>
+          <label className="text-sm block">Slots
+            <select value={form.num_slots}
+                    onChange={(e) => setForm({ ...form, num_slots: Number(e.target.value) })}
+                    className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+              <option value={1}>1</option><option value={2}>2</option>
+              <option value={3}>3</option><option value={4}>4</option>
+            </select>
+          </label>
+          <div className="flex gap-2">
+            <button onClick={save} disabled={patch.isPending}
+                    className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
+              Save
+            </button>
+            <button onClick={toggleDisabled}
+                    className="bg-slate-700 hover:bg-slate-600 rounded px-3 py-1.5">
+              {slot.status === 'disabled' ? 'Enable' : 'Disable'}
+            </button>
+            <button onClick={() => setConfirming(true)}
+                    className="bg-red-700 hover:bg-red-600 text-white rounded px-3 py-1.5 ml-auto">
+              Delete
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Attempts</h2>
+        <AttemptList attempts={slot.attempts} />
+      </section>
+
+      <ConfirmDialog
+        open={confirming}
+        title="Delete this wanted slot?"
+        body="This cannot be undone."
+        confirmLabel="Confirm"
+        onConfirm={confirmDelete}
+        onCancel={() => setConfirming(false)}
+      />
+    </main>
+  );
+}

--- a/web/src/pages/WantedDetailPage.tsx
+++ b/web/src/pages/WantedDetailPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { ApiError } from '../api/client';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { AttemptList } from '../components/AttemptList';
+import { PartnerPicker } from '../components/PartnerPicker';
 import { StatusPill } from '../components/StatusPill';
 import { useDeleteWanted, usePatchWanted, useWanted } from '../hooks/useWanted';
 
@@ -14,11 +15,21 @@ export function WantedDetailPage() {
   const patch = usePatchWanted(id);
   const del = useDeleteWanted();
   const [confirming, setConfirming] = useState(false);
-  const [form, setForm] = useState({ start_time: '', end_time: '', num_slots: 1 });
+  const [form, setForm] = useState<{
+    start_time: string;
+    end_time: string;
+    num_slots: number;
+    partners: string[];
+  }>({ start_time: '', end_time: '', num_slots: 1, partners: [] });
 
   useEffect(() => {
     if (slot) {
-      setForm({ start_time: slot.start_time, end_time: slot.end_time, num_slots: slot.num_slots });
+      setForm({
+        start_time: slot.start_time,
+        end_time: slot.end_time,
+        num_slots: slot.num_slots,
+        partners: slot.partners,
+      });
     }
   }, [slot]);
 
@@ -44,54 +55,64 @@ export function WantedDetailPage() {
   }
 
   return (
-    <main className="max-w-5xl mx-auto p-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h1 className="text-xl font-semibold">Edit</h1>
-          <StatusPill status={slot.status} />
-        </div>
-        <div className="space-y-3">
-          <div className="grid grid-cols-2 gap-3">
-            <label className="text-sm">Start
-              <input type="time" value={form.start_time}
-                     onChange={(e) => setForm({ ...form, start_time: e.target.value })}
-                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
-            </label>
-            <label className="text-sm">End
-              <input type="time" value={form.end_time}
-                     onChange={(e) => setForm({ ...form, end_time: e.target.value })}
-                     className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
-            </label>
-          </div>
-          <label className="text-sm block">Slots
-            <select value={form.num_slots}
-                    onChange={(e) => setForm({ ...form, num_slots: Number(e.target.value) })}
-                    className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
-              <option value={1}>1</option><option value={2}>2</option>
-              <option value={3}>3</option><option value={4}>4</option>
-            </select>
-          </label>
-          <div className="flex gap-2">
-            <button onClick={save} disabled={patch.isPending}
-                    className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
-              Save
-            </button>
-            <button onClick={toggleDisabled}
-                    className="bg-slate-700 hover:bg-slate-600 rounded px-3 py-1.5">
-              {slot.status === 'disabled' ? 'Enable' : 'Disable'}
-            </button>
-            <button onClick={() => setConfirming(true)}
-                    className="bg-red-700 hover:bg-red-600 text-white rounded px-3 py-1.5 ml-auto">
-              Delete
-            </button>
-          </div>
-        </div>
-      </section>
+    <main className="max-w-5xl mx-auto p-6">
+      <Link to="/wanted" className="text-sm text-slate-300 hover:text-slate-100 underline">
+        ← Back to wanted tee-times
+      </Link>
 
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Attempts</h2>
-        <AttemptList attempts={slot.attempts} />
-      </section>
+      <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h1 className="text-xl font-semibold">Edit</h1>
+            <StatusPill status={slot.status} />
+          </div>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="text-sm">Start
+                <input type="time" value={form.start_time}
+                       onChange={(e) => setForm({ ...form, start_time: e.target.value })}
+                       className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+              </label>
+              <label className="text-sm">End
+                <input type="time" value={form.end_time}
+                       onChange={(e) => setForm({ ...form, end_time: e.target.value })}
+                       className="block w-full bg-slate-900 border border-slate-700 rounded px-2 py-1" />
+              </label>
+            </div>
+            <label className="text-sm block">Slots
+              <select value={form.num_slots}
+                      onChange={(e) => setForm({ ...form, num_slots: Number(e.target.value) })}
+                      className="block bg-slate-900 border border-slate-700 rounded px-2 py-1">
+                <option value={1}>1</option><option value={2}>2</option>
+                <option value={3}>3</option><option value={4}>4</option>
+              </select>
+            </label>
+            <PartnerPicker
+              value={form.partners}
+              onChange={(partners) => setForm({ ...form, partners })}
+            />
+            <div className="flex gap-2">
+              <button onClick={save} disabled={patch.isPending}
+                      className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
+                Save
+              </button>
+              <button onClick={toggleDisabled}
+                      className="bg-slate-700 hover:bg-slate-600 rounded px-3 py-1.5">
+                {slot.status === 'disabled' ? 'Enable' : 'Disable'}
+              </button>
+              <button onClick={() => setConfirming(true)}
+                      className="bg-red-700 hover:bg-red-600 text-white rounded px-3 py-1.5 ml-auto">
+                Delete
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">Attempts</h2>
+          <AttemptList attempts={slot.attempts} />
+        </section>
+      </div>
 
       <ConfirmDialog
         open={confirming}

--- a/web/src/pages/WantedListPage.test.tsx
+++ b/web/src/pages/WantedListPage.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedListPage } from './WantedListPage';
+import type { WantedResponse } from '../api/types';
+
+const fixtures: WantedResponse[] = [
+  { id: '1', kind: 'one_shot', target_date: '2026-05-23',
+    day_of_week: null, end_date: null,
+    start_time: '14:00', end_time: '16:30', num_slots: 4, partners: [],
+    has_credentials: true, notify: null, status: 'pending', attempts: [],
+    created_at: '', updated_at: '' },
+  { id: '2', kind: 'recurring', target_date: null, day_of_week: 0, end_date: null,
+    start_time: '09:00', end_time: '11:00', num_slots: 2, partners: [],
+    has_credentials: true, notify: null, status: 'disabled', attempts: [],
+    created_at: '', updated_at: '' },
+];
+
+describe('WantedListPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('lists cards and filters by status', async () => {
+    server.use(http.get(`${baseUrl}/api/wanted`, () => HttpResponse.json(fixtures)));
+    renderWithProviders(<WantedListPage />, { initialAuth: { token: 'tok', username: 'alice' } });
+
+    expect(await screen.findByText(/Sat\b.+May/)).toBeInTheDocument();
+    expect(screen.getByText('Every Monday')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^Disabled$/ }));
+    expect(screen.queryByText(/Sat\b.+May/)).not.toBeInTheDocument();
+    expect(screen.getByText('Every Monday')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/WantedListPage.tsx
+++ b/web/src/pages/WantedListPage.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth/useAuth';
+import { useWantedList } from '../hooks/useWanted';
+import { WantedCard } from '../components/WantedCard';
+import type { WantedStatus } from '../api/types';
+
+type Filter = 'all' | WantedStatus;
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'pending', label: 'Pending' },
+  { key: 'booked', label: 'Booked' },
+  { key: 'disabled', label: 'Disabled' },
+  { key: 'expired', label: 'Expired' },
+];
+
+export function WantedListPage() {
+  const auth = useAuth();
+  const { data: slots, isLoading, error } = useWantedList();
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered = (slots ?? []).filter((s) => filter === 'all' ? true : s.status === filter);
+
+  return (
+    <main className="max-w-5xl mx-auto p-6">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Wanted tee-times</h1>
+        <div className="flex items-center gap-3 text-sm">
+          <Link to="/wanted/new"
+                className="bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1.5">
+            + New
+          </Link>
+          <span className="text-slate-400">Logged in as {auth.username}</span>
+          <button onClick={() => auth.logout()} className="text-slate-300 underline">Logout</button>
+        </div>
+      </header>
+
+      <div className="flex gap-2 mb-4">
+        {FILTERS.map((f) => (
+          <button key={f.key}
+                  onClick={() => setFilter(f.key)}
+                  className={`text-sm px-3 py-1 rounded-full border
+                              ${filter === f.key
+                                ? 'bg-slate-700 border-slate-500'
+                                : 'border-slate-700 hover:border-slate-500'}`}>
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-slate-400">Loading…</p>}
+      {error && <p className="text-red-400">Failed to load wanted slots.</p>}
+      {!isLoading && filtered.length === 0 && (
+        <p className="text-slate-400">No wanted slots match this filter.</p>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((s) => <WantedCard key={s.id} slot={s} />)}
+      </div>
+    </main>
+  );
+}

--- a/web/src/pages/WantedNewPage.test.tsx
+++ b/web/src/pages/WantedNewPage.test.tsx
@@ -1,0 +1,53 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server, baseUrl } from '../../test/handlers';
+import { renderWithProviders } from '../../test/utils';
+import { WantedNewPage } from './WantedNewPage';
+import { Route, Routes } from 'react-router-dom';
+
+describe('WantedNewPage', () => {
+  beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
+
+  it('submits a one-shot wanted slot and navigates back to /wanted', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let received: { url: string; body: any } | null = null;
+    server.use(http.post(`${baseUrl}/api/wanted`, async ({ request }) => {
+      received = { url: request.url, body: await request.json() };
+      return HttpResponse.json({ id: 'new' }, { status: 201 });
+    }));
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/wanted/new" element={<WantedNewPage />} />
+        <Route path="/wanted" element={<div>LIST</div>} />
+      </Routes>,
+      {
+        route: '/wanted/new',
+        initialAuth: { token: 'tok', credentialsBlob: 'BLOB' },
+      },
+    );
+
+    await userEvent.type(screen.getByLabelText(/target date/i), '2026-05-25');
+    await userEvent.clear(screen.getByLabelText(/^start$/i));
+    await userEvent.type(screen.getByLabelText(/^start$/i), '14:00');
+    await userEvent.clear(screen.getByLabelText(/^end$/i));
+    await userEvent.type(screen.getByLabelText(/^end$/i), '16:00');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
+    expect(received!.url).toContain('kind=one_shot');
+    expect(received!.body.credentials).toBe('BLOB');
+    expect(received!.body.target_date).toBe('2026-05-25');
+  });
+
+  it('toggles to Recurring mode', async () => {
+    renderWithProviders(<WantedNewPage />, {
+      route: '/wanted/new',
+      initialAuth: { token: 'tok', credentialsBlob: 'BLOB' },
+    });
+    await userEvent.click(screen.getByRole('tab', { name: /recurring/i }));
+    expect(screen.getByLabelText(/day of week/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/WantedNewPage.tsx
+++ b/web/src/pages/WantedNewPage.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ApiError } from '../api/client';
+import { useAuth } from '../auth/useAuth';
+import { useCreateWanted } from '../hooks/useWanted';
+import { OneShotForm } from '../components/OneShotForm';
+import { RecurringForm } from '../components/RecurringForm';
+import { encryptCredentials } from '../api/endpoints';
+
+type Mode = 'one_shot' | 'recurring';
+
+export function WantedNewPage() {
+  const [mode, setMode] = useState<Mode>('one_shot');
+  const [pinPrompt, setPinPrompt] = useState<{ user: string; pin: string }>({ user: '', pin: '' });
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const m = useCreateWanted();
+
+  async function obtainBlob(): Promise<string> {
+    if (auth.credentialsBlob) return auth.credentialsBlob;
+    if (!auth.username) throw new Error('Not authenticated');
+    if (!pinPrompt.pin) throw new Error('Re-enter PIN to save');
+    const { credentials } = await encryptCredentials({
+      username: auth.username, pin: pinPrompt.pin,
+    });
+    auth.setCredentialsBlob(credentials);
+    return credentials;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function submit(values: any) {
+    try {
+      const credentials = await obtainBlob();
+      await m.mutateAsync({ kind: mode, body: { ...values, credentials } });
+      toast.success('Wanted slot created');
+      navigate('/wanted');
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.detail : (e as Error).message;
+      toast.error(msg);
+    }
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">New wanted slot</h1>
+      <div role="tablist" className="inline-flex bg-slate-900 rounded p-1 mb-4">
+        <button role="tab" aria-selected={mode === 'one_shot'}
+                onClick={() => setMode('one_shot')}
+                className={`px-3 py-1 rounded ${mode === 'one_shot' ? 'bg-slate-700' : ''}`}>
+          One-shot
+        </button>
+        <button role="tab" aria-selected={mode === 'recurring'}
+                onClick={() => setMode('recurring')}
+                className={`px-3 py-1 rounded ${mode === 'recurring' ? 'bg-slate-700' : ''}`}>
+          Recurring
+        </button>
+      </div>
+
+      {!auth.credentialsBlob && (
+        <div className="mb-4 border border-amber-700/50 bg-amber-900/20 rounded p-3 text-sm">
+          <p className="mb-2">Re-enter your PIN to save credentials to this slot.</p>
+          <input type="password" placeholder="PIN"
+                 value={pinPrompt.pin}
+                 onChange={(e) => setPinPrompt({ user: auth.username ?? '', pin: e.target.value })}
+                 className="bg-slate-950 border border-slate-700 rounded px-2 py-1" />
+        </div>
+      )}
+
+      {mode === 'one_shot'
+        ? <OneShotForm onSubmit={submit} busy={m.isPending} />
+        : <RecurringForm onSubmit={submit} busy={m.isPending} />}
+    </main>
+  );
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,0 +1,23 @@
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+import { LoginPage } from './pages/LoginPage';
+import { WantedListPage } from './pages/WantedListPage';
+import { WantedNewPage } from './pages/WantedNewPage';
+import { WantedDetailPage } from './pages/WantedDetailPage';
+import { ProtectedRoute } from './auth/ProtectedRoute';
+
+const router = createBrowserRouter([
+  { path: '/login', element: <LoginPage /> },
+  {
+    element: <ProtectedRoute />,
+    children: [
+      { path: '/wanted', element: <WantedListPage /> },
+      { path: '/wanted/new', element: <WantedNewPage /> },
+      { path: '/wanted/:id', element: <WantedDetailPage /> },
+    ],
+  },
+  { path: '*', element: <Navigate to="/wanted" replace /> },
+]);
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare global {
+  interface Window {
+    __TSA_CONFIG__?: { apiBaseUrl?: string };
+  }
+}
+
+export {};

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config;

--- a/web/test/handlers.ts
+++ b/web/test/handlers.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+export const baseUrl = 'http://api.test';
+
+// Default happy-path handlers. Individual tests override per-case.
+export const handlers = [
+  http.post(`${baseUrl}/api/encrypt-credentials`, async ({ request }) => {
+    const body = (await request.json()) as { username: string; pin: string };
+    return HttpResponse.json({ credentials: `enc(${body.username}:${body.pin})` });
+  }),
+  http.post(`${baseUrl}/api/login`, () =>
+    HttpResponse.json({
+      access_token: 'test-token',
+      expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    }),
+  ),
+  http.get(`${baseUrl}/api/wanted`, () => HttpResponse.json([])),
+  http.get(`${baseUrl}/api/partners`, () => HttpResponse.json({ partners: [] })),
+];
+
+export const server = setupServer(...handlers);

--- a/web/test/setup.ts
+++ b/web/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from './handlers';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/web/test/utils.tsx
+++ b/web/test/utils.tsx
@@ -1,0 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../src/auth/AuthProvider';
+
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = '/', initialAuth }: { route?: string; initialAuth?: Parameters<typeof AuthProvider>[0]['initial'] } = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[route]}>
+        <AuthProvider initial={initialAuth}>{ui}</AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "test"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+    globals: true,
+    css: false,
+  },
+});


### PR DESCRIPTION
A React SPA at `web/` for managing **wanted tee-times** (persisted auto-booking requests): login + full CRUD — list with status filters, create one-shot/recurring, edit, enable/disable, delete, and per-slot attempt history.
Implements `docs/superpowers/specs/2026-05-20-wanted-tee-times-ui-design.md` (plan: `docs/superpowers/plans/2026-05-20-wanted-tee-times-ui.md`).
- **New `web/` package** — Vite + React + TypeScript + Tailwind + TanStack Query + React Router + Zod + react-hook-form. Tests: Vitest + React Testing Library + MSW (40 tests).
- **New backend endpoint** `POST /api/encrypt-credentials` — lets the browser obtain the AES-256-GCM blob used by `/api/login` and wanted-slot creation, so the shared secret never leaves the server.
- **Auth model** — bearer token in sessionStorage (survives reload), encrypted credentials blob in memory only (PIN re-prompt on reload before creating slots).
- **Deployment** — multi-stage nginx Dockerfile with runtime `API_BASE_URL` injection (`config.js`), new `charts/tee-sniper-web` Helm chart whose ingress path-splits `/api/*` → API service and `/*` → web service (no CORS).
- **CI** — `.github/workflows/web-build.yml` (npm ci + lint + vitest + build, then Docker build with `push: false`, matching the api/mcp workflows).
- Adds the `.claude/worktrees/` convention to `CLAUDE.md`.
- [ ] CI `web build` job green (lint, 40 vitest tests, Vite build, Docker build)
- [ ] CI `api build` green (new encrypt-credentials endpoint: roundtrip + 422 tests)
- [ ] `helm lint charts/tee-sniper-web` passes
- [ ] Manual: run API on :8000, `cd web && npm run dev`, log in, create a one-shot and a recurring slot, edit/disable/delete, verify attempt history renders
- [ ] Manual: confirm reload drops the in-memory blob and the PIN re-prompt appears on create
🤖 Generated with [Claude Code](https://claude.com/claude-code)