### PR TITLE
docs: document web UI + helm charts; publish web image on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,3 +152,23 @@ jobs:
           VERSION=${{ steps.version.outputs.VERSION_NUMBER }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Extract metadata for Web Docker image
+      id: meta-web
+      uses: docker/metadata-action@v6
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-web
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest
+
+    - name: Build and push Web Docker image
+      uses: docker/build-push-action@v7
+      with:
+        context: ./web
+        push: true
+        tags: ${{ steps.meta-web.outputs.tags }}
+        labels: ${{ steps.meta-web.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Automated golf tee-time booking. A Python FastAPI service stores encrypted
 credentials and booking sessions in Redis; the **wanted** API registers
 persisted booking requests (one-shot by date, or recurring by day-of-week);
 a daily worker processes due requests, books a matching slot, records the
-outcome, and optionally sends a Twilio SMS. An optional local MCP server
-exposes the booking operations to Claude Desktop / MetaMCP.
+outcome, and optionally sends a Twilio SMS. A React web UI drives the wanted
+workflow in the browser, and an optional local MCP server exposes the booking
+operations to Claude Desktop / MetaMCP.
 
 ## Components
 
@@ -13,8 +14,10 @@ exposes the booking operations to Claude Desktop / MetaMCP.
 |-----------|------|---------|
 | API service | `api/` | FastAPI: login, find/book tee times, manage partners, `wanted` requests |
 | Worker | `api/app/cli/worker.py` | Processes due `wanted` requests (run as a CronJob) |
+| Web UI | `web/` | Vite + React SPA for the wanted tee-times workflow (nginx-served) |
 | MCP server | `mcp/` | Local stdio MCP client of the REST API |
-| Helm chart | `charts/tee-sniper-api/` | Deploys API + Redis + opt-in worker CronJob |
+| API Helm chart | `charts/tee-sniper-api/` | Deploys API + Redis + opt-in worker CronJob |
+| Web Helm chart | `charts/tee-sniper-web/` | Deploys the web UI with path-based ingress (`/api/*` → API, `/*` → web) |
 
 ## How It Works
 
@@ -55,27 +58,81 @@ The API is configured via environment variables prefixed `TSA_`
 ## Running Locally
 
 ```bash
-# API + Redis via Docker Compose (dev override auto-loaded)
+# API + web + Redis via Docker Compose (dev override auto-loaded).
+# API on :8000, web UI on :8080, Redis on :6379.
 docker compose up
 
 # Or run the API directly
 cd api && .venv/bin/python -m uvicorn app.main:app --reload
 
+# Run the web UI dev server (proxies /api → http://localhost:8000)
+cd web && npm install && npm run dev      # serves on :5173
+
 # Run the wanted-slot worker once
 cd api && .venv/bin/python -m app.cli.worker
 ```
 
+The web UI reads its API base URL from `window.__TSA_CONFIG__.apiBaseUrl`,
+rewritten from the `API_BASE_URL` env var at container start (empty → relative
+`/api/*`). See `web/README.md` for details.
+
 ## Deployment
 
-Deploy with the Helm chart in `charts/tee-sniper-api/` (API + Redis, with
-an opt-in `worker` CronJob for `wanted` processing):
+Two Helm charts deploy the stack. Both pin images by tag (the API chart's
+schema rejects `tag=latest`); set `image.tag` / `api.image.tag` to a released
+version.
+
+### API chart (`charts/tee-sniper-api/`)
+
+Deploys the API, a bundled Redis (Bitnami subchart), and an opt-in `worker`
+CronJob for `wanted` processing. Requires `helm dep update` first to pull the
+Redis dependency.
 
 ```bash
-helm template charts/tee-sniper-api          # render
-# install/upgrade per your environment values file
+helm dep update charts/tee-sniper-api
+helm template testrel charts/tee-sniper-api -f charts/tee-sniper-api/values-dev.yaml   # render
+helm upgrade --install tee-sniper-api charts/tee-sniper-api \
+  -f charts/tee-sniper-api/values-prod.yaml
 ```
 
-See `charts/tee-sniper-api/values*.yaml` for environment-specific values.
+Key values (see `charts/tee-sniper-api/values.yaml`, `values-dev.yaml`,
+`values-prod.yaml`):
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `api.image.tag` | `.Chart.AppVersion` | API image tag (required, not `latest`) |
+| `api.existingSecret` | `tee-sniper-api` | Secret with `TSA_*` env (shared secret, base URL, etc.) |
+| `worker.enabled` | `false` | Enable the daily `wanted` worker CronJob |
+| `worker.schedule` | `30 6 * * *` | Worker cron schedule |
+| `worker.twilio.enabled` | `false` | Mount Twilio creds for SMS notifications |
+| `redis.enabled` | `true` | Deploy the bundled Redis subchart |
+| `networkPolicy.enabled` | `false` | Restrict API ingress to labelled clients |
+
+When `worker.enabled=true` you must also have `redis.enabled=true` or supply
+`TSA_REDIS_URL` via the chart secret — otherwise the worker connects to
+localhost and fails.
+
+### Web chart (`charts/tee-sniper-web/`)
+
+Deploys the nginx-served React UI with a path-based ingress that routes
+`/api/*` to the API service and `/*` to the web service on the same host.
+
+```bash
+helm template testrel charts/tee-sniper-web      # render
+helm upgrade --install tee-sniper-web charts/tee-sniper-web \
+  --set ingress.host=tee-sniper.example.com
+```
+
+Key values (see `charts/tee-sniper-web/values.yaml`):
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `image.tag` | `.Chart.AppVersion` | Web image tag |
+| `apiBaseUrl` | `""` | Browser API base; empty → relative `/api/*` (same-host ingress) |
+| `ingress.enabled` | `true` | Create the path-split ingress |
+| `ingress.host` | `tee-sniper.example.com` | Ingress hostname |
+| `ingress.apiServiceName` | `tee-sniper-api` | Service to route `/api/*` to |
+| `ingress.tls.enabled` | `false` | Enable TLS (set `ingress.tls.secretName`) |
 
 ## MCP Server
 
@@ -89,6 +146,9 @@ reference.
 # Python API tests
 cd api && .venv/bin/python -m pytest tests/ -v
 
+# Web tests (Vitest + RTL + MSW)
+cd web && npm install && npm test && npm run lint && npm run build
+
 # MCP tests
 cd mcp && uv sync --all-extras --dev && uv run pytest
 
@@ -101,18 +161,16 @@ cd api && .venv/bin/python -m pytest tests/test_session_integration.py
 
 - `.github/workflows/api-build.yml` — API build/test (provisions Redis,
   sets `TSA_REQUIRE_REDIS=1`).
+- `.github/workflows/web-build.yml` — Web lint/test/build, then a Docker
+  image build on PRs/pushes (built only, not pushed).
 - `.github/workflows/mcp-build.yml` — MCP build/test.
-- `.github/workflows/helm-chart.yml` — Helm chart lint/package.
+- `.github/workflows/helm-chart.yml` — Helm chart lint + `kubeconform`
+  validation of the API chart's dev/prod values (and asserts the schema
+  rejects `tag=latest`).
 - `.github/workflows/release.yml` — on `v*.*.*` tags: builds and pushes
-  the API Docker image (`ghcr.io/<repo>-api`), the MCP Docker image
-  (`ghcr.io/<repo>-mcp`), and the MCP wheel + sdist as release assets.
-
-## Roadmap
-
-Planned follow-up work (see `docs/superpowers/specs/` for designs):
-
-- [ ] **MCP tools for wanted tee-times** — expose create/list/delete of
-  wanted-slots via the MCP server (separate spec to follow).
+  the API Docker image (`ghcr.io/<repo>-api`), the web Docker image
+  (`ghcr.io/<repo>-web`), the MCP Docker image (`ghcr.io/<repo>-mcp`), and
+  the MCP wheel + sdist as release assets.
 
 ## License
 


### PR DESCRIPTION
- Update `README.md` to document the React web UI (`web/`) and both Helm charts (`tee-sniper-api`, `tee-sniper-web`), with per-chart deploy commands and key-values tables.
- Add web dev/test commands and the `web-build.yml` workflow to the docs; remove the now-shipped wanted-MCP-tools roadmap item.
- Add a web Docker image build/push step to `release.yml` so the `tee-sniper-web` chart's referenced image (`ghcr.io/<repo>-web`) is actually published on `v*.*.*` tags.
- [ ] Review README rendering on GitHub
- [ ] On the next `v*.*.*` tag, confirm `ghcr.io/<repo>-web` image is pushed
🤖 Generated with [Claude Code](https://claude.com/claude-code)