### PR TITLE
fix(web): unbreak WantedNewPage test (stale-date time bomb blocking CI)

### DIFF
--- a/web/src/pages/WantedNewPage.test.tsx
+++ b/web/src/pages/WantedNewPage.test.tsx
@@ -10,6 +10,10 @@ import { Route, Routes } from 'react-router-dom';
 describe('WantedNewPage', () => {
   beforeAll(() => { window.__TSA_CONFIG__ = { apiBaseUrl: baseUrl }; });
 
+  // OneShotForm constrains the date input to [today, today+7]. Compute the
+  // target relative to now so this test never drifts outside that window.
+  const targetDate = new Date(Date.now() + 3 * 86400_000).toISOString().slice(0, 10);
+
   it('submits a one-shot wanted slot and navigates back to /wanted', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let received: { url: string; body: any } | null = null;
@@ -29,7 +33,7 @@ describe('WantedNewPage', () => {
       },
     );
 
-    await userEvent.type(screen.getByLabelText(/target date/i), '2026-05-25');
+    await userEvent.type(screen.getByLabelText(/target date/i), targetDate);
     await userEvent.clear(screen.getByLabelText(/^start$/i));
     await userEvent.type(screen.getByLabelText(/^start$/i), '14:00');
     await userEvent.clear(screen.getByLabelText(/^end$/i));
@@ -39,7 +43,7 @@ describe('WantedNewPage', () => {
     await waitFor(() => expect(screen.getByText('LIST')).toBeInTheDocument());
     expect(received!.url).toContain('kind=one_shot');
     expect(received!.body.credentials).toBe('BLOB');
-    expect(received!.body.target_date).toBe('2026-05-25');
+    expect(received!.body.target_date).toBe(targetDate);
   });
 
   it('toggles to Recurring mode', async () => {


### PR DESCRIPTION
`web/src/pages/WantedNewPage.test.tsx` hardcoded `target_date: '2026-05-25'`, but `web/src/components/OneShotForm.tsx` constrains the date `<input>` to `[today, today+7]` (min/max derived from `new Date()`). Once "today" drifted past 2026-05-25, jsdom's HTML5 constraint validation silently blocked the form's submit event — neither the success nor validation-error callback fired — and the test failed.
This turned `main`'s **Web Build and Test** CI red on its own (unrelated to any dependency change), which in turn blocked the entire Renovate PR queue: every web dependency PR (#85, #86, #89–#96) fails on this same `test` job.
Compute the target date as `today + 3 days` at test time so it always lands inside the input's allowed window. The submitted-value assertion is preserved (now compares against the same computed date), so the test still verifies the request body carries the entered `target_date`.
- `cd web && npm test` → **42/42 pass** (was 41/42)
- `cd web && npm run lint` → clean
Once merged, the Renovate patch/minor PRs should go green after a rebase.
🤖 Generated with [Claude Code](https://claude.com/claude-code)